### PR TITLE
Support TILEDB_BLOB attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^0.21.1",
         "capnp-ts": "^0.7.0",
         "capnpc-ts": "^0.7.0",
-        "paralleljs": "github:SarantopoulosKon/parallel.js#node-mode-in-web-worker",
+        "paralleljs": "github:SarantopoulosKon/parallel.js#use-globalThis",
         "save-file": "^2.3.1"
       },
       "devDependencies": {
@@ -6785,8 +6785,7 @@
     },
     "node_modules/paralleljs": {
       "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/SarantopoulosKon/parallel.js.git#f68f6b1109f64b91b15a7827d1db439581b19e84",
-      "integrity": "sha512-37i0wPVEbnYG9TZWJgmtOqBQtg3V444LE3FvYuN88mWwkCHkhpjBURNc1sLsdhlX14fb733nX9x1pL0z7hbw0w==",
+      "resolved": "git+ssh://git@github.com/SarantopoulosKon/parallel.js.git#31efd1e7f2f611eaf6eab06b98d64da3c7cd7d45",
       "license": "MIT",
       "engines": {
         "node": ">=v14.18.1"
@@ -13330,9 +13329,8 @@
       "dev": true
     },
     "paralleljs": {
-      "version": "git+ssh://git@github.com/SarantopoulosKon/parallel.js.git#f68f6b1109f64b91b15a7827d1db439581b19e84",
-      "integrity": "sha512-37i0wPVEbnYG9TZWJgmtOqBQtg3V444LE3FvYuN88mWwkCHkhpjBURNc1sLsdhlX14fb733nX9x1pL0z7hbw0w==",
-      "from": "paralleljs@github:SarantopoulosKon/parallel.js#node-mode-in-web-worker"
+      "version": "git+ssh://git@github.com/SarantopoulosKon/parallel.js.git#31efd1e7f2f611eaf6eab06b98d64da3c7cd7d45",
+      "from": "paralleljs@github:SarantopoulosKon/parallel.js#use-globalThis"
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "axios": "^0.21.1",
     "capnp-ts": "^0.7.0",
     "capnpc-ts": "^0.7.0",
-    "paralleljs": "github:SarantopoulosKon/parallel.js#node-mode-in-web-worker",
+    "paralleljs": "github:SarantopoulosKon/parallel.js#use-globalThis",
     "save-file": "^2.3.1"
   },
   "devDependencies": {

--- a/src/TileDBQuery/TileDBQuery.ts
+++ b/src/TileDBQuery/TileDBQuery.ts
@@ -215,6 +215,7 @@ export class TileDBQuery {
        * Get the query response in capnp, we set responseType to arraybuffer instead of JSON
        * in order to deserialize the query capnp object.
        */
+
       const queryResponse = await this.queryAPI.submitQuery(
         namespace,
         arrayName,
@@ -247,8 +248,9 @@ export class TileDBQuery {
        * Deserialize buffer to a Query object
        */
       const queryObject = capnpQueryDeSerializer(bufferWithoutFirstEightBytes);
-
       const attributeHeaders = queryObject.attributeBufferHeaders;
+      console.log(JSON.stringify(attributeHeaders));
+      console.log('=================================');
 
       // Case it's incomplete query
       if (queryObject.status === Querystatus.Incomplete) {

--- a/src/TileDBQuery/TileDBQuery.ts
+++ b/src/TileDBQuery/TileDBQuery.ts
@@ -249,8 +249,6 @@ export class TileDBQuery {
        */
       const queryObject = capnpQueryDeSerializer(bufferWithoutFirstEightBytes);
       const attributeHeaders = queryObject.attributeBufferHeaders;
-      console.log(JSON.stringify(attributeHeaders));
-      console.log('=================================');
 
       // Case it's incomplete query
       if (queryObject.status === Querystatus.Incomplete) {

--- a/src/utils/bufferToData.ts
+++ b/src/utils/bufferToData.ts
@@ -86,6 +86,8 @@ const bufferToData = (arrayBuffer: ArrayBuffer, type: Datatype) => {
     return bufferToUTF32(arrayBuffer);
   } else if (int64Types.includes(type)) {
     return typedArrayToArray(bufferToInt64(arrayBuffer));
+  } else if (type === Datatype.Blob) {
+    return arrayBuffer;
   }
 
   return arrayBuffer;

--- a/src/utils/convertToArray.test.ts
+++ b/src/utils/convertToArray.test.ts
@@ -1,0 +1,18 @@
+import convertToArray from './convertToArray';
+
+describe('convertToArray()', () => {
+  it('Should return arrays as is', () => {
+    const result = convertToArray([1, 2, 3]);
+    expect(result).toStrictEqual([1, 2, 3]);
+  });
+
+  it('Should convert strings to arrays of chars', () => {
+    const result = convertToArray('hello');
+    expect(result).toStrictEqual(['h', 'e', 'l', 'l', 'o']);
+  });
+
+  it('Should convert Buffers to arrays of ints', () => {
+    const result = convertToArray(Uint8Array.from([1, 5, 12]).buffer);
+    expect(result).toStrictEqual([1, 5 , 12]);
+  });
+});

--- a/src/utils/convertToArray.ts
+++ b/src/utils/convertToArray.ts
@@ -1,4 +1,9 @@
 function convertToArray(arrayLike: any): any[] {
+  if (arrayLike.byteLength) {
+    const uint8Array = new Uint8Array(arrayLike);
+    const arrayOfUint8 = Array.from(uint8Array);
+    return arrayOfUint8;
+  }
   if (Array.isArray(arrayLike)) {
     return arrayLike;
   }

--- a/src/utils/dataToArrayBuffer.ts
+++ b/src/utils/dataToArrayBuffer.ts
@@ -36,6 +36,8 @@ const dataToArrayBuffer = (data: any = [], type: Datatype): ArrayBuffer => {
     // If it's an array of CHARs join them together to a single string
     const str = Array.isArray(data) ? data.join('') : data;
     return utf32StrToArrayBuffer(str);
+  } else if (type === Datatype.Blob) {
+    return data;
   }
 };
 

--- a/src/utils/getAttributeSchema.ts
+++ b/src/utils/getAttributeSchema.ts
@@ -1,4 +1,4 @@
-import { Attribute, Dimension } from '../v1';
+import { Attribute, Dimension } from '../v2';
 
 /**
  * Get attribute data from attribute name, attribute data contains the type of the attribute (e.g. INT32, StringUTF8 etc)

--- a/src/utils/getByteLengthOfData.ts
+++ b/src/utils/getByteLengthOfData.ts
@@ -43,6 +43,10 @@ const getByteLengthOfData = (data: number[] | string[], type: Datatype) => {
       return accum + encodedString.byteLength;
     }, 0);
   }
+
+  if (type === Datatype.Blob) {
+    return (data as any).byteLength;
+  }
 };
 
 export default getByteLengthOfData;

--- a/src/utils/getByteLengthOfDatatype.ts
+++ b/src/utils/getByteLengthOfDatatype.ts
@@ -12,6 +12,7 @@ const getByteLengthOfDatatype = (type: Datatype) => {
   } else if (
     type === Datatype.StringAscii ||
     type === Datatype.Char ||
+    type === Datatype.Blob ||
     type === Datatype.StringUtf8
   ) {
     return 1;

--- a/src/utils/getResultsFromArrayBuffer.ts
+++ b/src/utils/getResultsFromArrayBuffer.ts
@@ -29,7 +29,14 @@ export interface Options {
   returnRawBuffers?: boolean;
 }
 
-type Result = string[] | string | number[] | bigint[] | number[][] | bigint[][];
+type Result =
+  | string[]
+  | string
+  | number[]
+  | bigint[]
+  | number[][]
+  | bigint[][]
+  | ArrayBufferLike[];
 
 /**
  * Convert an ArrayBuffer to a map of attributes with their results
@@ -133,9 +140,13 @@ export const getResultsFromArrayBuffer = async (
           ? concatChars(groupedValues as string[][])
           : (groupedValues as number[][] | bigint[][]);
 
-        // Fix: Type
+        /**
+         * ParallelJS accepts data that are JSON serializable
+         * thus we have to convert buffer to array of uint8
+         * and after grouping convert the data back to ArrayBuffer.
+         */
         if (selectedAttributeSchema.type === Datatype.Blob) {
-          const arrayBuffers: any = groupedValues.map(
+          const arrayBuffers = groupedValues.map(
             ints => Uint8Array.from(ints).buffer
           );
           result = arrayBuffers;

--- a/src/utils/getResultsFromArrayBuffer.ts
+++ b/src/utils/getResultsFromArrayBuffer.ts
@@ -1,5 +1,4 @@
-import { Attribute, Dimension } from '../v1';
-import { AttributeBufferHeader } from '../v2';
+import { AttributeBufferHeader, Attribute, Dimension, Datatype } from '../v2';
 import getAttributeSizeInBytes from './getAttributeSizeInBytes';
 import getAttributeSchema from './getAttributeSchema';
 import getAttributeResult, { bufferToInt8 } from './bufferToData';
@@ -128,10 +127,19 @@ export const getResultsFromArrayBuffer = async (
           convertToArray(result),
           offsets
         );
+
         // If it's a string we concat all the characters to create array of strings
         result = isString
           ? concatChars(groupedValues as string[][])
           : (groupedValues as number[][] | bigint[][]);
+
+        // Fix: Type
+        if (selectedAttributeSchema.type === Datatype.Blob) {
+          const arrayBuffers: any = groupedValues.map(
+            ints => Uint8Array.from(ints).buffer
+          );
+          result = arrayBuffers;
+        }
       }
 
       if (isNullable && !options.ignoreNullables) {

--- a/src/utils/groupValuesByOffsetBytes.ts
+++ b/src/utils/groupValuesByOffsetBytes.ts
@@ -30,10 +30,9 @@ const groupValuesByOffsetBytes = <T>(
   return new Promise(resolve => {
     offsetsP
       .map(([offset, i]: [number, number]) => {
-        const vals = global.env.values as T[];
-        const globalOffsets = global.env.offsets;
+        const vals = globalThis.env.values as T[];
+        const globalOffsets = globalThis.env.offsets;
         const nextOffset = globalOffsets[i + 1];
-
         // Note: Array.prototype.slice doesn't accept BigInt
         const grpoupedValues = vals.slice(offset, nextOffset);
         return grpoupedValues;

--- a/src/utils/groupValuesByOffsetBytes.ts
+++ b/src/utils/groupValuesByOffsetBytes.ts
@@ -20,6 +20,7 @@ const groupValuesByOffsetBytes = <T>(
     off,
     offsetIndex[i]
   ]);
+
   const offsetsP = new Parallel(offsetIndexTuple, {
     env: {
       values,

--- a/src/v2/api.ts
+++ b/src/v2/api.ts
@@ -782,6 +782,7 @@ export enum Datatype {
     Uint32 = 'UINT32',
     Uint64 = 'UINT64',
     StringAscii = 'STRING_ASCII',
+    Blob = 'BLOB',
     StringUtf8 = 'STRING_UTF8',
     StringUtf16 = 'STRING_UTF16',
     StringUtf32 = 'STRING_UTF32',


### PR DESCRIPTION
Because of ParallelJS accepting data that are serializable as JSON, for var-length BLOB data we have to convert them to array of ints and back to buffers again, which might have a performance hit.