### PR TITLE
Add user supplied `axios` instance option

### DIFF
--- a/src/TileDBClient/TileDBClient.ts
+++ b/src/TileDBClient/TileDBClient.ts
@@ -62,13 +62,14 @@ class TileDBClient {
     params: Omit<
       ConfigurationParameters,
       'username' | 'password'
-    > = defaultConfig
+    > = defaultConfig,
+    axiosInstance?: AxiosInstance
   ) {
     const config = {
       ...defaultConfig,
       ...params
     };
-    this.axios = axios.create();
+    this.axios = axiosInstance ?? axios.create();
 
     this.config = new Configuration({
       ...config,


### PR DESCRIPTION
This PR adds the option to accept a user defined `axios` instance. Prior to this change the `axios` instance was constructed using the default `axios` configuration. 

In some scenarios the default `axios` configuration used in a project might be edited and be incompatible with TileDB Cloud and through this change a user provided `axios` can use a different configuration.