### PR TITLE
Reduce memory allocations for var-length data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@tiledb-inc/tiledb-cloud",
-  "version": "1.0.12",
+  "version": "2.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiledb-inc/tiledb-cloud",
-      "version": "1.0.12",
+      "version": "2.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2",
-        "paralleljs": "github:TileDB-Inc/parallel.js",
         "save-file": "^2.3.1"
       },
       "devDependencies": {
@@ -7156,14 +7155,6 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
-    },
-    "node_modules/paralleljs": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/TileDB-Inc/parallel.js.git#b9aa8a74bfb1918f026328cbd3d47ca656d3f7c9",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v20.x"
-      }
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiledb-inc/tiledb-cloud",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.6",
   "description": "JavaScript client for the TileDB Cloud Service.",
   "type": "module",
   "files": [
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "axios": "^1.12.2",
-    "paralleljs": "github:TileDB-Inc/parallel.js",
     "save-file": "^2.3.1"
   },
   "devDependencies": {
@@ -57,6 +56,7 @@
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
     "axios-mock-adapter": "^2.1.0",
+    "capnp-es": "^0.0.11",
     "eslint": "^9.37.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
@@ -67,8 +67,7 @@
     "typescript-eslint": "^8.46.0",
     "vite": "7.1.9",
     "vite-plugin-dts": "4.5.4",
-    "vitest": "3.2.4",
-    "capnp-es": "^0.0.11"
+    "vitest": "3.2.4"
   },
   "repository": {
     "type": "git",

--- a/src/TileDBClient/TileDBClient.ts
+++ b/src/TileDBClient/TileDBClient.ts
@@ -509,7 +509,7 @@ class TileDBClient {
       query
     )) {
       notebookContents = notebookContents.concat(
-        (results as NotebookOrFileDimensions).contents
+        (results as unknown as NotebookOrFileDimensions).contents
       );
     }
 
@@ -576,7 +576,7 @@ class TileDBClient {
       query
     )) {
       fileContents = fileContents.concat(
-        (results as NotebookOrFileDimensions).contents
+        (results as unknown as NotebookOrFileDimensions).contents
       );
     }
 

--- a/src/utils/enumerationToHumanReadable/enumerationToHumanReadable.ts
+++ b/src/utils/enumerationToHumanReadable/enumerationToHumanReadable.ts
@@ -31,7 +31,7 @@ const enumerationToHumanReadable = async (enumeration: Enumeration) => {
       Number(o / BigInt(BYTE_PER_ELEMENT))
     );
 
-    const groupedValues = await groupValuesByOffsetBytes(
+    const groupedValues = groupValuesByOffsetBytes(
       convertToArray(values),
       offsetsAsNumbers
     );

--- a/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
+++ b/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
@@ -324,930 +324,488 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
       30000
     );
   });
+});
 
-  describe('Variable-length attributes performance', () => {
-    it(
-      'Should handle large var-length string attributes efficiently',
-      async () => {
-        // Create buffer with many string values
-        const numStrings = 10000;
-        const avgStringLength = 20;
+describe('getResultsFromArrayBuffer() - UTF-32 String Tests', () => {
+  it('Should handle var-length UTF-32 strings (non-fast-path)', async () => {
+    // UTF-32 uses 4 bytes per character
+    const strings = ['Hello', 'World', 'UTF32', '🎉🎊'];
+    const numStrings = strings.length;
 
-        // Generate strings
-        const strings: string[] = [];
-        for (let i = 0; i < numStrings; i++) {
-          strings.push(`String_${i}_${'x'.repeat(avgStringLength)}`);
-        }
+    // Encode strings as UTF-32LE (4 bytes per code point)
+    const encodedStrings: Uint32Array[] = [];
+    let totalCodePoints = 0;
 
-        const fullString = strings.join('');
-        const stringBytes = new TextEncoder().encode(fullString);
+    for (const str of strings) {
+      const codePoints = Array.from(str).map(char => char.codePointAt(0)!);
+      encodedStrings.push(new Uint32Array(codePoints));
+      totalCodePoints += codePoints.length;
+    }
 
-        // Create offsets (byte offsets)
-        const offsets = new BigUint64Array(numStrings);
-        let currentOffset = 0;
-        for (let i = 0; i < numStrings; i++) {
-          offsets[i] = BigInt(currentOffset);
-          currentOffset += new TextEncoder().encode(strings[i]).length;
-        }
+    // Calculate byte offsets
+    const offsets = new BigUint64Array(numStrings);
+    let byteOffset = 0;
+    for (let i = 0; i < numStrings; i++) {
+      offsets[i] = BigInt(byteOffset);
+      byteOffset += encodedStrings[i].length * 4; // 4 bytes per code point
+    }
 
-        const offsetsBytes = numStrings * 8; // 8 bytes per BigUint64
-        const validityBytes = numStrings; // 1 byte per element
-        const totalBytes = offsetsBytes + stringBytes.length + validityBytes;
+    const offsetsBytes = numStrings * 8;
+    const stringDataBytes = totalCodePoints * 4; // 4 bytes per code point
+    const validityBytes = numStrings;
+    const totalBytes = offsetsBytes + stringDataBytes + validityBytes;
 
-        // Build buffer: [offsets][string data][validity]
-        const buffer = new ArrayBuffer(totalBytes);
-        const offsetView = new BigUint64Array(buffer, 0, numStrings);
-        offsetView.set(offsets);
-        const stringView = new Uint8Array(
-          buffer,
-          offsetsBytes,
-          stringBytes.length
-        );
-        stringView.set(stringBytes);
-        const validityView = new Uint8Array(
-          buffer,
-          offsetsBytes + stringBytes.length,
-          validityBytes
-        );
-        validityView.fill(1); // All valid
+    const buffer = new ArrayBuffer(totalBytes);
 
-        const bufferHeaders = [
-          {
-            name: 'strings',
-            fixedLenBufferSizeInBytes: offsetsBytes,
-            varLenBufferSizeInBytes: stringBytes.length,
-            validityLenBufferSizeInBytes: validityBytes,
-            originalFixedLenBufferSizeInBytes: offsetsBytes,
-            originalVarLenBufferSizeInBytes: stringBytes.length,
-            originalValidityLenBufferSizeInBytes: validityBytes
-          }
-        ];
+    // Write offsets
+    new BigUint64Array(buffer, 0, numStrings).set(offsets);
 
-        const schema = [
-          {
-            cellValNum: 4294967295,
-            name: 'strings',
-            type: Datatype.StringUtf8,
-            filterPipeline: {},
-            fillValue: [0],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
+    // Write string data as UTF-32LE
+    const stringDataView = new Uint8Array(buffer, offsetsBytes, stringDataBytes);
+    let writePos = 0;
+    for (const encoded of encodedStrings) {
+      const bytes = new Uint8Array(encoded.buffer);
+      stringDataView.set(bytes, writePos);
+      writePos += bytes.length;
+    }
 
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
+    // Write validity (all valid)
+    const validityView = new Uint8Array(
+      buffer,
+      offsetsBytes + stringDataBytes,
+      validityBytes
+    );
+    validityView.fill(1);
 
-        expect((results.strings as string[]).length).toBe(numStrings);
-        expect((results.strings as string[])[0]).toBe(strings[0]);
+    const bufferHeaders = [
+      {
+        name: 'utf32_strings',
+        fixedLenBufferSizeInBytes: offsetsBytes,
+        varLenBufferSizeInBytes: stringDataBytes,
+        validityLenBufferSizeInBytes: validityBytes,
+        originalFixedLenBufferSizeInBytes: offsetsBytes,
+        originalVarLenBufferSizeInBytes: stringDataBytes,
+        originalValidityLenBufferSizeInBytes: validityBytes
+      }
+    ];
 
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Var-length strings (${numStrings} strings, avg ${avgStringLength} chars): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
+    const schema = [
+      {
+        cellValNum: 4294967295,
+        name: 'utf32_strings',
+        type: Datatype.StringUtf32,
+        filterPipeline: {},
+        fillValue: [0],
+        nullable: true,
+        fillValueValidity: false
+      }
+    ];
 
-        expect(elapsedTime).toBeLessThan(10000); // 10 seconds max
-      },
-      30000
+    const results = await getResultsFromArrayBuffer(
+      new DataView(buffer),
+      bufferHeaders,
+      schema
     );
 
-    it(
-      'Should handle large var-length numeric arrays efficiently',
-      async () => {
-        const numArrays = 5000;
-        const avgArrayLength = 10;
-
-        // Generate array values
-        let totalValues = 0;
-        const offsets = new BigUint64Array(numArrays);
-        const values: number[] = [];
-
-        for (let i = 0; i < numArrays; i++) {
-          offsets[i] = BigInt(totalValues);
-          const arrayLength = Math.floor(Math.random() * avgArrayLength) + 1;
-          for (let j = 0; j < arrayLength; j++) {
-            values.push(Math.floor(Math.random() * 1000));
-          }
-          totalValues += arrayLength;
-        }
-
-        const offsetsBytes = numArrays * 8;
-        const valuesBytes = totalValues * 4; // Int32
-        const validityBytes = numArrays;
-        const totalBytes = offsetsBytes + valuesBytes + validityBytes;
-
-        // Build buffer
-        const buffer = new ArrayBuffer(totalBytes);
-        const offsetView = new BigUint64Array(buffer, 0, numArrays);
-        offsetView.set(offsets);
-        const valuesView = new Int32Array(
-          buffer,
-          offsetsBytes,
-          totalValues
-        );
-        valuesView.set(values);
-        const validityView = new Uint8Array(
-          buffer,
-          offsetsBytes + valuesBytes,
-          validityBytes
-        );
-        validityView.fill(1);
-
-        const bufferHeaders = [
-          {
-            name: 'arrays',
-            fixedLenBufferSizeInBytes: offsetsBytes,
-            varLenBufferSizeInBytes: valuesBytes,
-            validityLenBufferSizeInBytes: validityBytes,
-            originalFixedLenBufferSizeInBytes: offsetsBytes,
-            originalVarLenBufferSizeInBytes: valuesBytes,
-            originalValidityLenBufferSizeInBytes: validityBytes
-          }
-        ];
-
-        const schema = [
-          {
-            cellValNum: 4294967295,
-            name: 'arrays',
-            type: Datatype.Int32,
-            filterPipeline: {},
-            fillValue: [0, 0, 0, 128],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
-
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
-
-        expect((results.arrays as number[][]).length).toBe(numArrays);
-
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Var-length numeric arrays (${numArrays} arrays, ${totalValues} total values): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
-
-        expect(elapsedTime).toBeLessThan(15000); // 15 seconds max
-      },
-      30000
-    );
+    const resultStrings = results.utf32_strings as string[];
+    expect(resultStrings.length).toBe(numStrings);
+    expect(resultStrings[0]).toBe('Hello');
+    expect(resultStrings[1]).toBe('World');
+    expect(resultStrings[2]).toBe('UTF32');
+    expect(resultStrings[3]).toBe('🎉🎊');
   });
 
-  describe('Nullable attributes performance', () => {
-    it(
-      'Should handle large nullable datasets efficiently',
-      async () => {
-        const numElements = 50000;
-        const bytesPerElement = 4;
-        const dataBytes = numElements * bytesPerElement;
-        const validityBytes = numElements;
-        const totalBytes = dataBytes + validityBytes;
+  it('Should handle nullable UTF-32 strings', async () => {
+    const strings = ['Test', 'UTF32', 'Data', 'Null'];
+    const numStrings = strings.length;
 
-        const buffer = new ArrayBuffer(totalBytes);
-        const dataView = new Int32Array(buffer, 0, numElements);
-        const validityView = new Uint8Array(buffer, dataBytes, validityBytes);
+    // Encode strings as UTF-32LE
+    const encodedStrings: Uint32Array[] = [];
+    let totalCodePoints = 0;
 
-        // Fill with data and set 20% as null
-        for (let i = 0; i < numElements; i++) {
-          dataView[i] = i * 2;
-          validityView[i] = Math.random() > 0.2 ? 1 : 0;
-        }
+    for (const str of strings) {
+      const codePoints = Array.from(str).map(char => char.codePointAt(0)!);
+      encodedStrings.push(new Uint32Array(codePoints));
+      totalCodePoints += codePoints.length;
+    }
 
-        const bufferHeaders = [
-          {
-            name: 'nullable_data',
-            fixedLenBufferSizeInBytes: dataBytes,
-            varLenBufferSizeInBytes: 0,
-            validityLenBufferSizeInBytes: validityBytes,
-            originalFixedLenBufferSizeInBytes: dataBytes,
-            originalVarLenBufferSizeInBytes: 0,
-            originalValidityLenBufferSizeInBytes: validityBytes
-          }
-        ];
+    const offsets = new BigUint64Array(numStrings);
+    let byteOffset = 0;
+    for (let i = 0; i < numStrings; i++) {
+      offsets[i] = BigInt(byteOffset);
+      byteOffset += encodedStrings[i].length * 4;
+    }
 
-        const schema = [
-          {
-            cellValNum: 1,
-            name: 'nullable_data',
-            type: Datatype.Int32,
-            filterPipeline: {},
-            fillValue: [0, 0, 0, 128],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
+    const offsetsBytes = numStrings * 8;
+    const stringDataBytes = totalCodePoints * 4;
+    const validityBytes = numStrings;
+    const totalBytes = offsetsBytes + stringDataBytes + validityBytes;
 
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
+    const buffer = new ArrayBuffer(totalBytes);
 
-        expect((results.nullable_data as Array<number | null>).length).toBe(
-          numElements
-        );
+    // Write offsets
+    new BigUint64Array(buffer, 0, numStrings).set(offsets);
 
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Nullable attributes (${numElements} elements, ~20% null): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
+    // Write string data
+    const stringDataView = new Uint8Array(buffer, offsetsBytes, stringDataBytes);
+    let writePos = 0;
+    for (const encoded of encodedStrings) {
+      const bytes = new Uint8Array(encoded.buffer);
+      stringDataView.set(bytes, writePos);
+      writePos += bytes.length;
+    }
 
-        expect(elapsedTime).toBeLessThan(5000); // 5 seconds max
-      },
-      30000
+    // Write validity - make index 1 and 3 null
+    const validityView = new Uint8Array(
+      buffer,
+      offsetsBytes + stringDataBytes,
+      validityBytes
+    );
+    validityView[0] = 1;
+    validityView[1] = 0; // null
+    validityView[2] = 1;
+    validityView[3] = 0; // null
+
+    const bufferHeaders = [
+      {
+        name: 'utf32_strings',
+        fixedLenBufferSizeInBytes: offsetsBytes,
+        varLenBufferSizeInBytes: stringDataBytes,
+        validityLenBufferSizeInBytes: validityBytes,
+        originalFixedLenBufferSizeInBytes: offsetsBytes,
+        originalVarLenBufferSizeInBytes: stringDataBytes,
+        originalValidityLenBufferSizeInBytes: validityBytes
+      }
+    ];
+
+    const schema = [
+      {
+        cellValNum: 4294967295,
+        name: 'utf32_strings',
+        type: Datatype.StringUtf32,
+        filterPipeline: {},
+        fillValue: [0],
+        nullable: true,
+        fillValueValidity: false
+      }
+    ];
+
+    const results = await getResultsFromArrayBuffer(
+      new DataView(buffer),
+      bufferHeaders,
+      schema
     );
 
-    it(
-      'Should skip nullable processing when ignoreNullables is true',
-      async () => {
-        const numElements = 50000;
-        const bytesPerElement = 4;
-        const dataBytes = numElements * bytesPerElement;
-        const validityBytes = numElements;
-        const totalBytes = dataBytes + validityBytes;
-
-        const buffer = new ArrayBuffer(totalBytes);
-        const dataView = new Int32Array(buffer, 0, numElements);
-        const validityView = new Uint8Array(buffer, dataBytes, validityBytes);
-
-        for (let i = 0; i < numElements; i++) {
-          dataView[i] = i * 2;
-          validityView[i] = i % 5 === 0 ? 0 : 1; // 20% null
-        }
-
-        const bufferHeaders = [
-          {
-            name: 'nullable_data',
-            fixedLenBufferSizeInBytes: dataBytes,
-            varLenBufferSizeInBytes: 0,
-            validityLenBufferSizeInBytes: validityBytes,
-            originalFixedLenBufferSizeInBytes: dataBytes,
-            originalVarLenBufferSizeInBytes: 0,
-            originalValidityLenBufferSizeInBytes: validityBytes
-          }
-        ];
-
-        const schema = [
-          {
-            cellValNum: 1,
-            name: 'nullable_data',
-            type: Datatype.Int32,
-            filterPipeline: {},
-            fillValue: [0, 0, 0, 128],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
-
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema,
-          { ignoreNullables: true }
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
-
-        // With ignoreNullables, no nulls should be in result
-        expect((results.nullable_data as number[]).every(v => v !== null)).toBe(
-          true
-        );
-
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Nullable ignored (${numElements} elements): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
-
-        // Should be faster than processing nullables
-        expect(elapsedTime).toBeLessThan(3000); // 3 seconds max
-      },
-      30000
-    );
+    const resultStrings = results.utf32_strings as Array<string | null>;
+    expect(resultStrings.length).toBe(numStrings);
+    expect(resultStrings[0]).toBe('Test');
+    expect(resultStrings[1]).toBeNull();
+    expect(resultStrings[2]).toBe('Data');
+    expect(resultStrings[3]).toBeNull();
   });
 
-  describe('Mixed workload performance', () => {
-    it(
-      'Should handle complex mixed attribute types efficiently',
-      async () => {
-        const numRows = 10000;
+  it('Should handle UTF-32 strings with emoji and special characters', async () => {
+    // Test strings with various Unicode characters including emoji
+    const strings = [
+      '😀😃😄', // Emoji
+      'Δημοκρατία', // Greek
+      '中文字符', // Chinese
+      '🚀🌟💻', // More emoji
+      'Ñoño' // Latin with accents
+    ];
+    const numStrings = strings.length;
 
-        // Build a complex buffer with multiple attribute types
-        // Fixed int, var-length strings, nullable floats, var-length int arrays
+    const encodedStrings: Uint32Array[] = [];
+    let totalCodePoints = 0;
 
-        // 1. Fixed length dimension (rows)
-        const rowsBytes = numRows * 4;
-        const rowsData = new Int32Array(numRows);
-        for (let i = 0; i < numRows; i++) {
-          rowsData[i] = i;
-        }
+    for (const str of strings) {
+      const codePoints = Array.from(str).map(char => char.codePointAt(0)!);
+      encodedStrings.push(new Uint32Array(codePoints));
+      totalCodePoints += codePoints.length;
+    }
 
-        // 2. Var-length strings
-        const strings = Array.from(
-          { length: numRows },
-          (_, i) => `Record_${i}`
-        );
-        const fullString = strings.join('');
-        const stringBytes = new TextEncoder().encode(fullString);
-        const stringOffsets = new BigUint64Array(numRows);
-        let offset = 0;
-        for (let i = 0; i < numRows; i++) {
-          stringOffsets[i] = BigInt(offset);
-          offset += new TextEncoder().encode(strings[i]).length;
-        }
-        const stringOffsetsBytes = numRows * 8;
-        const stringDataBytes = stringBytes.length;
-        const stringValidityBytes = numRows;
+    const offsets = new BigUint64Array(numStrings);
+    let byteOffset = 0;
+    for (let i = 0; i < numStrings; i++) {
+      offsets[i] = BigInt(byteOffset);
+      byteOffset += encodedStrings[i].length * 4;
+    }
 
-        // 3. Nullable floats
-        const floatsBytes = numRows * 8; // Float64
-        const floatsData = new Float64Array(numRows);
-        const floatsValidityBytes = numRows;
-        const floatsValidity = new Uint8Array(floatsValidityBytes);
-        for (let i = 0; i < numRows; i++) {
-          floatsData[i] = Math.random() * 1000;
-          floatsValidity[i] = i % 10 === 0 ? 0 : 1; // 10% null
-        }
+    const offsetsBytes = numStrings * 8;
+    const stringDataBytes = totalCodePoints * 4;
+    const validityBytes = numStrings;
+    const totalBytes = offsetsBytes + stringDataBytes + validityBytes;
 
-        // Calculate padding needed for Float64Array alignment (must be multiple of 8)
-        const beforeFloatOffset = 
-          rowsBytes + 
-          stringOffsetsBytes + 
-          stringDataBytes + 
-          stringValidityBytes;
-        const paddingBytes = (8 - (beforeFloatOffset % 8)) % 8;
+    const buffer = new ArrayBuffer(totalBytes);
 
-        // Calculate total buffer size
-        const totalBytes =
-          rowsBytes +
-          stringOffsetsBytes +
-          stringDataBytes +
-          stringValidityBytes +
-          paddingBytes +
-          floatsBytes +
-          floatsValidityBytes;
+    // Write offsets
+    new BigUint64Array(buffer, 0, numStrings).set(offsets);
 
-        const buffer = new ArrayBuffer(totalBytes);
-        let currentOffset = 0;
+    // Write string data
+    const stringDataView = new Uint8Array(buffer, offsetsBytes, stringDataBytes);
+    let writePos = 0;
+    for (const encoded of encodedStrings) {
+      const bytes = new Uint8Array(encoded.buffer);
+      stringDataView.set(bytes, writePos);
+      writePos += bytes.length;
+    }
 
-        // Write rows
-        new Int32Array(buffer, currentOffset, numRows).set(rowsData);
-        currentOffset += rowsBytes;
-
-        // Write string offsets
-        new BigUint64Array(buffer, currentOffset, numRows).set(stringOffsets);
-        currentOffset += stringOffsetsBytes;
-
-        // Write string data
-        new Uint8Array(buffer, currentOffset, stringBytes.length).set(
-          stringBytes
-        );
-        currentOffset += stringDataBytes;
-
-        // Write string validity
-        new Uint8Array(buffer, currentOffset, stringValidityBytes).fill(1);
-        currentOffset += stringValidityBytes;
-
-        // Add padding
-        currentOffset += paddingBytes;
-
-        // Write floats (now properly aligned)
-        new Float64Array(buffer, currentOffset, numRows).set(floatsData);
-        currentOffset += floatsBytes;
-
-        // Write float validity
-        new Uint8Array(buffer, currentOffset, floatsValidityBytes).set(
-          floatsValidity
-        );
-
-        const bufferHeaders = [
-          {
-            name: 'rows',
-            fixedLenBufferSizeInBytes: rowsBytes,
-            varLenBufferSizeInBytes: 0,
-            validityLenBufferSizeInBytes: 0,
-            originalFixedLenBufferSizeInBytes: rowsBytes,
-            originalVarLenBufferSizeInBytes: 0,
-            originalValidityLenBufferSizeInBytes: 0
-          },
-          {
-            name: 'names',
-            fixedLenBufferSizeInBytes: stringOffsetsBytes,
-            varLenBufferSizeInBytes: stringDataBytes,
-            validityLenBufferSizeInBytes: stringValidityBytes,
-            originalFixedLenBufferSizeInBytes: stringOffsetsBytes,
-            originalVarLenBufferSizeInBytes: stringDataBytes,
-            originalValidityLenBufferSizeInBytes: stringValidityBytes
-          },
-          {
-            name: 'values',
-            fixedLenBufferSizeInBytes: floatsBytes,
-            varLenBufferSizeInBytes: 0,
-            validityLenBufferSizeInBytes: floatsValidityBytes,
-            originalFixedLenBufferSizeInBytes: floatsBytes,
-            originalVarLenBufferSizeInBytes: 0,
-            originalValidityLenBufferSizeInBytes: floatsValidityBytes
-          }
-        ];
-
-        const schema = [
-          {
-            name: 'rows',
-            nullTileExtent: false,
-            type: Datatype.Int32,
-            tileExtent: { int32: 4 },
-            domain: { int32: [] },
-            filterPipeline: {}
-          },
-          {
-            cellValNum: 4294967295,
-            name: 'names',
-            type: Datatype.StringUtf8,
-            filterPipeline: {},
-            fillValue: [0],
-            nullable: true,
-            fillValueValidity: false
-          },
-          {
-            cellValNum: 1,
-            name: 'values',
-            type: Datatype.Float64,
-            filterPipeline: {},
-            fillValue: [0, 0, 0, 0, 0, 0, 0, 0],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
-
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
-
-        expect((results.rows as number[]).length).toBe(numRows);
-        expect((results.names as string[]).length).toBe(numRows);
-        expect((results.values as Array<number | null>).length).toBe(numRows);
-
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Mixed workload (${numRows} rows, 3 different attribute types): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
-
-        expect(elapsedTime).toBeLessThan(10000); // 10 seconds max
-      },
-      30000
+    // Write validity (all valid)
+    const validityView = new Uint8Array(
+      buffer,
+      offsetsBytes + stringDataBytes,
+      validityBytes
     );
+    validityView.fill(1);
+
+    const bufferHeaders = [
+      {
+        name: 'utf32_strings',
+        fixedLenBufferSizeInBytes: offsetsBytes,
+        varLenBufferSizeInBytes: stringDataBytes,
+        validityLenBufferSizeInBytes: validityBytes,
+        originalFixedLenBufferSizeInBytes: offsetsBytes,
+        originalVarLenBufferSizeInBytes: stringDataBytes,
+        originalValidityLenBufferSizeInBytes: validityBytes
+      }
+    ];
+
+    const schema = [
+      {
+        cellValNum: 4294967295,
+        name: 'utf32_strings',
+        type: Datatype.StringUtf32,
+        filterPipeline: {},
+        fillValue: [0],
+        nullable: true,
+        fillValueValidity: false
+      }
+    ];
+
+    const results = await getResultsFromArrayBuffer(
+      new DataView(buffer),
+      bufferHeaders,
+      schema
+    );
+
+    const resultStrings = results.utf32_strings as string[];
+    expect(resultStrings.length).toBe(numStrings);
+    expect(resultStrings[0]).toBe('😀😃😄');
+    expect(resultStrings[1]).toBe('Δημοκρατία');
+    expect(resultStrings[2]).toBe('中文字符');
+    expect(resultStrings[3]).toBe('🚀🌟💻');
+    expect(resultStrings[4]).toBe('Ñoño');
   });
 
-  describe('Big data var-length attributes performance (100K scale)', () => {
-    it(
-      'Should handle 100K var-length nullable strings efficiently',
-      async () => {
-        const numStrings = 100000;
-        const encoder = new TextEncoder();
+  it('Should handle empty UTF-32 strings', async () => {
+    const strings = ['Hello', '', 'World', '', 'End'];
+    const numStrings = strings.length;
 
-        // Generate strings with varying lengths (5-50 chars)
-        const strings: string[] = new Array(numStrings);
-        for (let i = 0; i < numStrings; i++) {
-          const len = 5 + (i % 46); // lengths from 5 to 50
-          strings[i] = `s${i}_${'a'.repeat(len)}`;
-        }
+    const encodedStrings: Uint32Array[] = [];
+    let totalCodePoints = 0;
 
-        // Encode all strings and compute byte offsets
-        const encodedStrings = strings.map(s => encoder.encode(s));
-        const offsets = new BigUint64Array(numStrings);
-        let totalStringBytes = 0;
-        for (let i = 0; i < numStrings; i++) {
-          offsets[i] = BigInt(totalStringBytes);
-          totalStringBytes += encodedStrings[i].length;
-        }
+    for (const str of strings) {
+      if (str.length === 0) {
+        encodedStrings.push(new Uint32Array(0));
+      } else {
+        const codePoints = Array.from(str).map(char => char.codePointAt(0)!);
+        encodedStrings.push(new Uint32Array(codePoints));
+        totalCodePoints += codePoints.length;
+      }
+    }
 
-        const offsetsBytes = numStrings * 8;
-        const validityBytes = numStrings;
-        const totalBytes = offsetsBytes + totalStringBytes + validityBytes;
+    const offsets = new BigUint64Array(numStrings);
+    let byteOffset = 0;
+    for (let i = 0; i < numStrings; i++) {
+      offsets[i] = BigInt(byteOffset);
+      byteOffset += encodedStrings[i].length * 4;
+    }
 
-        const buffer = new ArrayBuffer(totalBytes);
+    const offsetsBytes = numStrings * 8;
+    const stringDataBytes = totalCodePoints * 4;
+    const validityBytes = numStrings;
+    const totalBytes = offsetsBytes + stringDataBytes + validityBytes;
 
-        // Write offsets
-        new BigUint64Array(buffer, 0, numStrings).set(offsets);
+    const buffer = new ArrayBuffer(totalBytes);
 
-        // Write string data
-        const stringDataView = new Uint8Array(buffer, offsetsBytes, totalStringBytes);
-        let writePos = 0;
-        for (let i = 0; i < numStrings; i++) {
-          stringDataView.set(encodedStrings[i], writePos);
-          writePos += encodedStrings[i].length;
-        }
+    // Write offsets
+    new BigUint64Array(buffer, 0, numStrings).set(offsets);
 
-        // Write validity — 15% null
-        const validityView = new Uint8Array(
-          buffer,
-          offsetsBytes + totalStringBytes,
-          validityBytes
-        );
-        for (let i = 0; i < numStrings; i++) {
-          validityView[i] = i % 7 === 0 ? 0 : 1;
-        }
+    // Write string data
+    const stringDataView = new Uint8Array(buffer, offsetsBytes, stringDataBytes);
+    let writePos = 0;
+    for (const encoded of encodedStrings) {
+      if (encoded.length > 0) {
+        const bytes = new Uint8Array(encoded.buffer);
+        stringDataView.set(bytes, writePos);
+        writePos += bytes.length;
+      }
+    }
 
-        const bufferHeaders = [
-          {
-            name: 'labels',
-            fixedLenBufferSizeInBytes: offsetsBytes,
-            varLenBufferSizeInBytes: totalStringBytes,
-            validityLenBufferSizeInBytes: validityBytes,
-            originalFixedLenBufferSizeInBytes: offsetsBytes,
-            originalVarLenBufferSizeInBytes: totalStringBytes,
-            originalValidityLenBufferSizeInBytes: validityBytes
-          }
-        ];
+    // Write validity (all valid)
+    const validityView = new Uint8Array(
+      buffer,
+      offsetsBytes + stringDataBytes,
+      validityBytes
+    );
+    validityView.fill(1);
 
-        const schema = [
-          {
-            cellValNum: 4294967295,
-            name: 'labels',
-            type: Datatype.StringUtf8,
-            filterPipeline: {},
-            fillValue: [0],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
+    const bufferHeaders = [
+      {
+        name: 'utf32_strings',
+        fixedLenBufferSizeInBytes: offsetsBytes,
+        varLenBufferSizeInBytes: stringDataBytes,
+        validityLenBufferSizeInBytes: validityBytes,
+        originalFixedLenBufferSizeInBytes: offsetsBytes,
+        originalVarLenBufferSizeInBytes: stringDataBytes,
+        originalValidityLenBufferSizeInBytes: validityBytes
+      }
+    ];
 
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
+    const schema = [
+      {
+        cellValNum: 4294967295,
+        name: 'utf32_strings',
+        type: Datatype.StringUtf32,
+        filterPipeline: {},
+        fillValue: [0],
+        nullable: true,
+        fillValueValidity: false
+      }
+    ];
 
-        const labels = results.labels as Array<string | null>;
-        expect(labels.length).toBe(numStrings);
-
-        // Verify a sample of non-null values
-        expect(labels[1]).toBe(strings[1]);
-        expect(labels[10]).toBe(strings[10]);
-        expect(labels[99999]).toBe(strings[99999]);
-
-        // Verify nulls are applied correctly
-        expect(labels[0]).toBeNull();
-        expect(labels[7]).toBeNull();
-        expect(labels[14]).toBeNull();
-        expect(labels[1]).not.toBeNull();
-
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Big data var-length strings (${numStrings} strings, ~${(totalStringBytes / numStrings).toFixed(0)} avg bytes, 15% null): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
-
-        expect(elapsedTime).toBeLessThan(5000);
-      },
-      30000
+    const results = await getResultsFromArrayBuffer(
+      new DataView(buffer),
+      bufferHeaders,
+      schema
     );
 
-    it(
-      'Should handle 100K var-length numeric arrays with variable sizes efficiently',
-      async () => {
-        const numArrays = 100000;
-
-        // Pre-calculate total values so we can allocate upfront
-        const arraySizes = new Array(numArrays);
-        let totalValues = 0;
-        for (let i = 0; i < numArrays; i++) {
-          // Varying sizes: 1 to 20 elements per cell
-          arraySizes[i] = 1 + (i % 20);
-          totalValues += arraySizes[i];
-        }
-
-        const offsetsBytes = numArrays * 8;
-        const bytesPerElement = 4; // Int32
-        const valuesBytes = totalValues * bytesPerElement;
-        const validityBytes = numArrays;
-        const totalBytes = offsetsBytes + valuesBytes + validityBytes;
-
-        const buffer = new ArrayBuffer(totalBytes);
-
-        // Write offsets (byte offsets for Int32 values)
-        const offsetView = new BigUint64Array(buffer, 0, numArrays);
-        let byteOffset = 0;
-        for (let i = 0; i < numArrays; i++) {
-          offsetView[i] = BigInt(byteOffset);
-          byteOffset += arraySizes[i] * bytesPerElement;
-        }
-
-        // Write values
-        const valuesView = new Int32Array(buffer, offsetsBytes, totalValues);
-        let valIdx = 0;
-        for (let i = 0; i < numArrays; i++) {
-          for (let j = 0; j < arraySizes[i]; j++) {
-            valuesView[valIdx++] = i * 100 + j;
-          }
-        }
-
-        // Write validity — 10% null
-        const validityView = new Uint8Array(
-          buffer,
-          offsetsBytes + valuesBytes,
-          validityBytes
-        );
-        for (let i = 0; i < numArrays; i++) {
-          validityView[i] = i % 10 === 0 ? 0 : 1;
-        }
-
-        const bufferHeaders = [
-          {
-            name: 'vectors',
-            fixedLenBufferSizeInBytes: offsetsBytes,
-            varLenBufferSizeInBytes: valuesBytes,
-            validityLenBufferSizeInBytes: validityBytes,
-            originalFixedLenBufferSizeInBytes: offsetsBytes,
-            originalVarLenBufferSizeInBytes: valuesBytes,
-            originalValidityLenBufferSizeInBytes: validityBytes
-          }
-        ];
-
-        const schema = [
-          {
-            cellValNum: 4294967295,
-            name: 'vectors',
-            type: Datatype.Int32,
-            filterPipeline: {},
-            fillValue: [0, 0, 0, 128],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
-
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
-
-        const vectors = results.vectors as Array<number[] | null>;
-        expect(vectors.length).toBe(numArrays);
-
-        // Verify null entries
-        expect(vectors[0]).toBeNull();
-        expect(vectors[10]).toBeNull();
-        expect(vectors[1]).not.toBeNull();
-
-        // Verify a non-null array has the correct length and first value
-        expect(vectors[1]!.length).toBe(arraySizes[1]);
-        expect(vectors[1]![0]).toBe(100);
-
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Big data var-length Int32 arrays (${numArrays} arrays, ${totalValues} total values, avg ${(totalValues / numArrays).toFixed(1)} per cell): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
-
-        expect(elapsedTime).toBeLessThan(10000);
-      },
-      30000
-    );
-
-    it(
-      'Should handle 100K rows with multiple var-length attributes combined',
-      async () => {
-        const numRows = 100000;
-        const encoder = new TextEncoder();
-
-        // --- Dimension: rows (fixed Int32) ---
-        const rowsBytes = numRows * 4;
-
-        // --- Attribute 1: var-length nullable strings ---
-        const strings: string[] = new Array(numRows);
-        for (let i = 0; i < numRows; i++) {
-          strings[i] = `item_${i}_${'z'.repeat(i % 30)}`;
-        }
-        const encodedStrings = strings.map(s => encoder.encode(s));
-        const strOffsets = new BigUint64Array(numRows);
-        let totalStrBytes = 0;
-        for (let i = 0; i < numRows; i++) {
-          strOffsets[i] = BigInt(totalStrBytes);
-          totalStrBytes += encodedStrings[i].length;
-        }
-        const strOffsetsBytes = numRows * 8;
-        const strValidityBytes = numRows;
-
-        // --- Attribute 2: var-length nullable Int32 arrays ---
-        const arraySizes = new Array(numRows);
-        let totalInts = 0;
-        for (let i = 0; i < numRows; i++) {
-          arraySizes[i] = 1 + (i % 10);
-          totalInts += arraySizes[i];
-        }
-        const intOffsetsBytes = numRows * 8;
-        const intBytesPerElement = 4;
-        const intValuesBytes = totalInts * intBytesPerElement;
-        const intValidityBytes = numRows;
-
-        // Compute total buffer: rows + strOffsets + strData + strValidity + intOffsets + intValues + intValidity
-        // Need to ensure BigUint64Array alignment for intOffsets
-        const afterStrValidity = rowsBytes + strOffsetsBytes + totalStrBytes + strValidityBytes;
-        const intOffsetsPadding = (8 - (afterStrValidity % 8)) % 8;
-
-        const totalBytes =
-          rowsBytes +
-          strOffsetsBytes + totalStrBytes + strValidityBytes +
-          intOffsetsPadding +
-          intOffsetsBytes + intValuesBytes + intValidityBytes;
-
-        const buffer = new ArrayBuffer(totalBytes);
-        let pos = 0;
-
-        // Write rows
-        const rowsView = new Int32Array(buffer, pos, numRows);
-        for (let i = 0; i < numRows; i++) rowsView[i] = i;
-        pos += rowsBytes;
-
-        // Write string offsets
-        new BigUint64Array(buffer, pos, numRows).set(strOffsets);
-        pos += strOffsetsBytes;
-
-        // Write string data
-        const strDataView = new Uint8Array(buffer, pos, totalStrBytes);
-        let strWritePos = 0;
-        for (let i = 0; i < numRows; i++) {
-          strDataView.set(encodedStrings[i], strWritePos);
-          strWritePos += encodedStrings[i].length;
-        }
-        pos += totalStrBytes;
-
-        // Write string validity — 20% null
-        const strValidityView = new Uint8Array(buffer, pos, strValidityBytes);
-        for (let i = 0; i < numRows; i++) {
-          strValidityView[i] = i % 5 === 0 ? 0 : 1;
-        }
-        pos += strValidityBytes;
-
-        // Padding for alignment
-        pos += intOffsetsPadding;
-
-        // Write int array offsets (byte offsets)
-        const intOffsetsView = new BigUint64Array(buffer, pos, numRows);
-        let intByteOff = 0;
-        for (let i = 0; i < numRows; i++) {
-          intOffsetsView[i] = BigInt(intByteOff);
-          intByteOff += arraySizes[i] * intBytesPerElement;
-        }
-        pos += intOffsetsBytes;
-
-        // Write int values
-        const intValuesView = new Int32Array(buffer, pos, totalInts);
-        let intIdx = 0;
-        for (let i = 0; i < numRows; i++) {
-          for (let j = 0; j < arraySizes[i]; j++) {
-            intValuesView[intIdx++] = i + j;
-          }
-        }
-        pos += intValuesBytes;
-
-        // Write int validity — 25% null
-        const intValidityView = new Uint8Array(buffer, pos, intValidityBytes);
-        for (let i = 0; i < numRows; i++) {
-          intValidityView[i] = i % 4 === 0 ? 0 : 1;
-        }
-
-        const bufferHeaders = [
-          {
-            name: 'rows',
-            fixedLenBufferSizeInBytes: rowsBytes,
-            varLenBufferSizeInBytes: 0,
-            validityLenBufferSizeInBytes: 0,
-            originalFixedLenBufferSizeInBytes: rowsBytes,
-            originalVarLenBufferSizeInBytes: 0,
-            originalValidityLenBufferSizeInBytes: 0
-          },
-          {
-            name: 'labels',
-            fixedLenBufferSizeInBytes: strOffsetsBytes,
-            varLenBufferSizeInBytes: totalStrBytes,
-            validityLenBufferSizeInBytes: strValidityBytes + intOffsetsPadding,
-            originalFixedLenBufferSizeInBytes: strOffsetsBytes,
-            originalVarLenBufferSizeInBytes: totalStrBytes,
-            originalValidityLenBufferSizeInBytes: strValidityBytes + intOffsetsPadding
-          },
-          {
-            name: 'data',
-            fixedLenBufferSizeInBytes: intOffsetsBytes,
-            varLenBufferSizeInBytes: intValuesBytes,
-            validityLenBufferSizeInBytes: intValidityBytes,
-            originalFixedLenBufferSizeInBytes: intOffsetsBytes,
-            originalVarLenBufferSizeInBytes: intValuesBytes,
-            originalValidityLenBufferSizeInBytes: intValidityBytes
-          }
-        ];
-
-        const schema = [
-          {
-            name: 'rows',
-            nullTileExtent: false,
-            type: Datatype.Int32,
-            tileExtent: { int32: 4 },
-            domain: { int32: [] },
-            filterPipeline: {}
-          },
-          {
-            cellValNum: 4294967295,
-            name: 'labels',
-            type: Datatype.StringUtf8,
-            filterPipeline: {},
-            fillValue: [0],
-            nullable: true,
-            fillValueValidity: false
-          },
-          {
-            cellValNum: 4294967295,
-            name: 'data',
-            type: Datatype.Int32,
-            filterPipeline: {},
-            fillValue: [0, 0, 0, 128],
-            nullable: true,
-            fillValueValidity: false
-          }
-        ];
-
-        const memBefore = getMemoryMetrics();
-        const startTime = performance.now();
-        const results = await getResultsFromArrayBuffer(
-          new DataView(buffer),
-          bufferHeaders,
-          schema
-        );
-        const endTime = performance.now();
-        const memAfter = getMemoryMetrics();
-
-        const rows = results.rows as number[];
-        const labels = results.labels as Array<string | null>;
-        const data = results.data as Array<number[] | null>;
-
-        expect(rows.length).toBe(numRows);
-        expect(labels.length).toBe(numRows);
-        expect(data.length).toBe(numRows);
-
-        // Spot-check rows
-        expect(rows[0]).toBe(0);
-        expect(rows[numRows - 1]).toBe(numRows - 1);
-
-        // Spot-check string nulls (every 5th)
-        expect(labels[0]).toBeNull();
-        expect(labels[5]).toBeNull();
-        expect(labels[1]).toBe(strings[1]);
-
-        // Spot-check int array nulls (every 4th) and values
-        expect(data[0]).toBeNull();
-        expect(data[4]).toBeNull();
-        expect(data[1]).not.toBeNull();
-        expect(data[1]!.length).toBe(arraySizes[1]);
-        expect(data[1]![0]).toBe(1);
-
-        const elapsedTime = endTime - startTime;
-        console.log(
-          `Big data multi-attribute (${numRows} rows: fixed dim + var-len strings + var-len Int32[], 20%/25% null): ${elapsedTime.toFixed(2)}ms`
-        );
-        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
-
-        expect(elapsedTime).toBeLessThan(10000);
-      },
-      30000
-    );
+    const resultStrings = results.utf32_strings as string[];
+    expect(resultStrings.length).toBe(numStrings);
+    expect(resultStrings[0]).toBe('Hello');
+    expect(resultStrings[1]).toBe('');
+    expect(resultStrings[2]).toBe('World');
+    expect(resultStrings[3]).toBe('');
+    expect(resultStrings[4]).toBe('End');
   });
+
+  it(
+    'Should handle large UTF-32 string dataset with performance tracking',
+    async () => {
+      const numStrings = 100_000;
+      const strings: string[] = [];
+
+      // Generate varied UTF-32 strings
+      for (let i = 0; i < numStrings; i++) {
+        if (i % 2 === 0) {
+          strings.push(`emoji_${i}_🎉🚀💻`);
+        } else if (i % 3 === 0) {
+          strings.push(`greek_${i}_Δημοκρατία`);
+        } else {
+          strings.push(`text_${i}_regular`);
+        }
+      }
+
+      const encodedStrings: Uint32Array[] = [];
+      let totalCodePoints = 0;
+
+      for (const str of strings) {
+        const codePoints = Array.from(str).map(char => char.codePointAt(0)!);
+        encodedStrings.push(new Uint32Array(codePoints));
+        totalCodePoints += codePoints.length;
+      }
+
+      const offsets = new BigUint64Array(numStrings);
+      let byteOffset = 0;
+      for (let i = 0; i < numStrings; i++) {
+        offsets[i] = BigInt(byteOffset);
+        byteOffset += encodedStrings[i].length * 4;
+      }
+
+      const offsetsBytes = numStrings * 8;
+      const stringDataBytes = totalCodePoints * 4;
+      const validityBytes = numStrings;
+      const totalBytes = offsetsBytes + stringDataBytes + validityBytes;
+
+      const buffer = new ArrayBuffer(totalBytes);
+
+      // Write offsets
+      new BigUint64Array(buffer, 0, numStrings).set(offsets);
+
+      // Write string data
+      const stringDataView = new Uint8Array(buffer, offsetsBytes, stringDataBytes);
+      let writePos = 0;
+      for (const encoded of encodedStrings) {
+        const bytes = new Uint8Array(encoded.buffer);
+        stringDataView.set(bytes, writePos);
+        writePos += bytes.length;
+      }
+
+      // Write validity - 20% null
+      const validityView = new Uint8Array(
+        buffer,
+        offsetsBytes + stringDataBytes,
+        validityBytes
+      );
+      for (let i = 0; i < numStrings; i++) {
+        validityView[i] = i % 5 === 0 ? 0 : 1;
+      }
+
+      const bufferHeaders = [
+        {
+          name: 'utf32_strings',
+          fixedLenBufferSizeInBytes: offsetsBytes,
+          varLenBufferSizeInBytes: stringDataBytes,
+          validityLenBufferSizeInBytes: validityBytes,
+          originalFixedLenBufferSizeInBytes: offsetsBytes,
+          originalVarLenBufferSizeInBytes: stringDataBytes,
+          originalValidityLenBufferSizeInBytes: validityBytes
+        }
+      ];
+
+      const schema = [
+        {
+          cellValNum: 4294967295,
+          name: 'utf32_strings',
+          type: Datatype.StringUtf32,
+          filterPipeline: {},
+          fillValue: [0],
+          nullable: true,
+          fillValueValidity: false
+        }
+      ];
+
+      const memBefore = getMemoryMetrics();
+      const startTime = performance.now();
+      const results = await getResultsFromArrayBuffer(
+        new DataView(buffer),
+        bufferHeaders,
+        schema
+      );
+      const endTime = performance.now();
+      const memAfter = getMemoryMetrics();
+
+      const resultStrings = results.utf32_strings as Array<string | null>;
+      expect(resultStrings.length).toBe(numStrings);
+
+      // Verify nulls
+      expect(resultStrings[0]).toBeNull();
+      expect(resultStrings[5]).toBeNull();
+      expect(resultStrings[10]).toBeNull();
+
+      // Verify non-null values
+      expect(resultStrings[1]).toBe(strings[1]);
+      expect(resultStrings[2]).toBe(strings[2]);
+      expect(resultStrings[999]).toBe(strings[999]);
+
+      const elapsedTime = endTime - startTime;
+      console.log(
+        `UTF-32 strings (${numStrings} strings, ~${(totalCodePoints / numStrings).toFixed(1)} avg code points, 20% null): ${elapsedTime.toFixed(2)}ms`
+      );
+      console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
+
+      expect(elapsedTime).toBeLessThan(5000);
+    },
+    30000
+  );
 });

--- a/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
+++ b/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
@@ -11,6 +11,7 @@ import {
   varLenNullableAttributesSchema
 } from '../../fixtures/attributes';
 import { describe, it, expect } from 'vitest';
+import { Datatype } from '../../v3';
 
 describe('getResultsFromArrayBuffer()', () => {
   it('Should convert a raw ArrayBuffer to a results object with fixed length attributes', async () => {
@@ -116,5 +117,656 @@ describe('getResultsFromArrayBuffer()', () => {
     );
 
     expect(results).toEqual({ cols: new ArrayBuffer(0) });
+  });
+});
+
+describe('getResultsFromArrayBuffer() - Performance Tests', () => {
+  describe('Fixed-length attributes performance', () => {
+    it(
+      'Should handle large fixed-length ArrayBuffer efficiently',
+      async () => {
+        // Create a large buffer with 100,000 elements per attribute
+        const numElements = 100000;
+        const numAttributes = 4;
+        const bytesPerElement = 4; // Int32
+        const totalBytes = numElements * bytesPerElement * numAttributes;
+
+        const buffer = new ArrayBuffer(totalBytes);
+        const view = new Int32Array(buffer);
+
+        // Fill with test data
+        for (let i = 0; i < view.length; i++) {
+          view[i] = i % 1000;
+        }
+
+        const largeBufferHeaders = [
+          {
+            name: 'cols',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'rows',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'a0',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'a3',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          largeBufferHeaders,
+          fixedLenAttributesSchema
+        );
+        const endTime = performance.now();
+
+        expect(Object.keys(results)).toHaveLength(4);
+        expect((results.cols as number[]).length).toBe(numElements);
+        expect((results.rows as number[]).length).toBe(numElements);
+        expect((results.a0 as number[]).length).toBe(numElements);
+        expect((results.a3 as number[]).length).toBe(numElements);
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Fixed-length processing (${numElements} elements): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        // Performance assertion - should complete in reasonable time
+        expect(elapsedTime).toBeLessThan(5000); // 5 seconds max
+      },
+      30000
+    );
+
+    it(
+      'Should handle returnRawBuffers option efficiently for large data',
+      async () => {
+        const numElements = 100000;
+        const bytesPerElement = 4;
+        const totalBytes = numElements * bytesPerElement * 4;
+
+        const buffer = new ArrayBuffer(totalBytes);
+        const view = new Int32Array(buffer);
+
+        for (let i = 0; i < view.length; i++) {
+          view[i] = i;
+        }
+
+        const largeBufferHeaders = [
+          {
+            name: 'cols',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'rows',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'a0',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'a3',
+            fixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: numElements * bytesPerElement,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          largeBufferHeaders,
+          fixedLenAttributesSchema,
+          { returnRawBuffers: true }
+        );
+        const endTime = performance.now();
+
+        expect(results.cols).toBeInstanceOf(ArrayBuffer);
+        expect((results.cols as ArrayBuffer).byteLength).toBe(
+          numElements * bytesPerElement
+        );
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `returnRawBuffers (${numElements} elements): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        // Raw buffers should be much faster as no conversion happens
+        expect(elapsedTime).toBeLessThan(1000); // 1 second max
+      },
+      30000
+    );
+  });
+
+  describe('Variable-length attributes performance', () => {
+    it(
+      'Should handle large var-length string attributes efficiently',
+      async () => {
+        // Create buffer with many string values
+        const numStrings = 10000;
+        const avgStringLength = 20;
+
+        // Generate strings
+        const strings: string[] = [];
+        for (let i = 0; i < numStrings; i++) {
+          strings.push(`String_${i}_${'x'.repeat(avgStringLength)}`);
+        }
+
+        const fullString = strings.join('');
+        const stringBytes = new TextEncoder().encode(fullString);
+
+        // Create offsets (byte offsets)
+        const offsets = new BigUint64Array(numStrings);
+        let currentOffset = 0;
+        for (let i = 0; i < numStrings; i++) {
+          offsets[i] = BigInt(currentOffset);
+          currentOffset += new TextEncoder().encode(strings[i]).length;
+        }
+
+        const offsetsBytes = numStrings * 8; // 8 bytes per BigUint64
+        const validityBytes = numStrings; // 1 byte per element
+        const totalBytes = offsetsBytes + stringBytes.length + validityBytes;
+
+        // Build buffer: [offsets][string data][validity]
+        const buffer = new ArrayBuffer(totalBytes);
+        const offsetView = new BigUint64Array(buffer, 0, numStrings);
+        offsetView.set(offsets);
+        const stringView = new Uint8Array(
+          buffer,
+          offsetsBytes,
+          stringBytes.length
+        );
+        stringView.set(stringBytes);
+        const validityView = new Uint8Array(
+          buffer,
+          offsetsBytes + stringBytes.length,
+          validityBytes
+        );
+        validityView.fill(1); // All valid
+
+        const bufferHeaders = [
+          {
+            name: 'strings',
+            fixedLenBufferSizeInBytes: offsetsBytes,
+            varLenBufferSizeInBytes: stringBytes.length,
+            validityLenBufferSizeInBytes: validityBytes,
+            originalFixedLenBufferSizeInBytes: offsetsBytes,
+            originalVarLenBufferSizeInBytes: stringBytes.length,
+            originalValidityLenBufferSizeInBytes: validityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            cellValNum: 4294967295,
+            name: 'strings',
+            type: Datatype.StringUtf8,
+            filterPipeline: {},
+            fillValue: [0],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema
+        );
+        const endTime = performance.now();
+
+        expect((results.strings as string[]).length).toBe(numStrings);
+        expect((results.strings as string[])[0]).toBe(strings[0]);
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Var-length strings (${numStrings} strings, avg ${avgStringLength} chars): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        expect(elapsedTime).toBeLessThan(10000); // 10 seconds max
+      },
+      30000
+    );
+
+    it(
+      'Should handle large var-length numeric arrays efficiently',
+      async () => {
+        const numArrays = 5000;
+        const avgArrayLength = 10;
+
+        // Generate array values
+        let totalValues = 0;
+        const offsets = new BigUint64Array(numArrays);
+        const values: number[] = [];
+
+        for (let i = 0; i < numArrays; i++) {
+          offsets[i] = BigInt(totalValues);
+          const arrayLength = Math.floor(Math.random() * avgArrayLength) + 1;
+          for (let j = 0; j < arrayLength; j++) {
+            values.push(Math.floor(Math.random() * 1000));
+          }
+          totalValues += arrayLength;
+        }
+
+        const offsetsBytes = numArrays * 8;
+        const valuesBytes = totalValues * 4; // Int32
+        const validityBytes = numArrays;
+        const totalBytes = offsetsBytes + valuesBytes + validityBytes;
+
+        // Build buffer
+        const buffer = new ArrayBuffer(totalBytes);
+        const offsetView = new BigUint64Array(buffer, 0, numArrays);
+        offsetView.set(offsets);
+        const valuesView = new Int32Array(
+          buffer,
+          offsetsBytes,
+          totalValues
+        );
+        valuesView.set(values);
+        const validityView = new Uint8Array(
+          buffer,
+          offsetsBytes + valuesBytes,
+          validityBytes
+        );
+        validityView.fill(1);
+
+        const bufferHeaders = [
+          {
+            name: 'arrays',
+            fixedLenBufferSizeInBytes: offsetsBytes,
+            varLenBufferSizeInBytes: valuesBytes,
+            validityLenBufferSizeInBytes: validityBytes,
+            originalFixedLenBufferSizeInBytes: offsetsBytes,
+            originalVarLenBufferSizeInBytes: valuesBytes,
+            originalValidityLenBufferSizeInBytes: validityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            cellValNum: 4294967295,
+            name: 'arrays',
+            type: Datatype.Int32,
+            filterPipeline: {},
+            fillValue: [0, 0, 0, 128],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema
+        );
+        const endTime = performance.now();
+
+        expect((results.arrays as number[][]).length).toBe(numArrays);
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Var-length numeric arrays (${numArrays} arrays, ${totalValues} total values): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        expect(elapsedTime).toBeLessThan(15000); // 15 seconds max
+      },
+      30000
+    );
+  });
+
+  describe('Nullable attributes performance', () => {
+    it(
+      'Should handle large nullable datasets efficiently',
+      async () => {
+        const numElements = 50000;
+        const bytesPerElement = 4;
+        const dataBytes = numElements * bytesPerElement;
+        const validityBytes = numElements;
+        const totalBytes = dataBytes + validityBytes;
+
+        const buffer = new ArrayBuffer(totalBytes);
+        const dataView = new Int32Array(buffer, 0, numElements);
+        const validityView = new Uint8Array(buffer, dataBytes, validityBytes);
+
+        // Fill with data and set 20% as null
+        for (let i = 0; i < numElements; i++) {
+          dataView[i] = i * 2;
+          validityView[i] = Math.random() > 0.2 ? 1 : 0;
+        }
+
+        const bufferHeaders = [
+          {
+            name: 'nullable_data',
+            fixedLenBufferSizeInBytes: dataBytes,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: validityBytes,
+            originalFixedLenBufferSizeInBytes: dataBytes,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: validityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            cellValNum: 1,
+            name: 'nullable_data',
+            type: Datatype.Int32,
+            filterPipeline: {},
+            fillValue: [0, 0, 0, 128],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema
+        );
+        const endTime = performance.now();
+
+        expect((results.nullable_data as Array<number | null>).length).toBe(
+          numElements
+        );
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Nullable attributes (${numElements} elements, ~20% null): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        expect(elapsedTime).toBeLessThan(5000); // 5 seconds max
+      },
+      30000
+    );
+
+    it(
+      'Should skip nullable processing when ignoreNullables is true',
+      async () => {
+        const numElements = 50000;
+        const bytesPerElement = 4;
+        const dataBytes = numElements * bytesPerElement;
+        const validityBytes = numElements;
+        const totalBytes = dataBytes + validityBytes;
+
+        const buffer = new ArrayBuffer(totalBytes);
+        const dataView = new Int32Array(buffer, 0, numElements);
+        const validityView = new Uint8Array(buffer, dataBytes, validityBytes);
+
+        for (let i = 0; i < numElements; i++) {
+          dataView[i] = i * 2;
+          validityView[i] = i % 5 === 0 ? 0 : 1; // 20% null
+        }
+
+        const bufferHeaders = [
+          {
+            name: 'nullable_data',
+            fixedLenBufferSizeInBytes: dataBytes,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: validityBytes,
+            originalFixedLenBufferSizeInBytes: dataBytes,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: validityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            cellValNum: 1,
+            name: 'nullable_data',
+            type: Datatype.Int32,
+            filterPipeline: {},
+            fillValue: [0, 0, 0, 128],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema,
+          { ignoreNullables: true }
+        );
+        const endTime = performance.now();
+
+        // With ignoreNullables, no nulls should be in result
+        expect((results.nullable_data as number[]).every(v => v !== null)).toBe(
+          true
+        );
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Nullable ignored (${numElements} elements): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        // Should be faster than processing nullables
+        expect(elapsedTime).toBeLessThan(3000); // 3 seconds max
+      },
+      30000
+    );
+  });
+
+  describe('Mixed workload performance', () => {
+    it(
+      'Should handle complex mixed attribute types efficiently',
+      async () => {
+        const numRows = 10000;
+
+        // Build a complex buffer with multiple attribute types
+        // Fixed int, var-length strings, nullable floats, var-length int arrays
+
+        // 1. Fixed length dimension (rows)
+        const rowsBytes = numRows * 4;
+        const rowsData = new Int32Array(numRows);
+        for (let i = 0; i < numRows; i++) {
+          rowsData[i] = i;
+        }
+
+        // 2. Var-length strings
+        const strings = Array.from(
+          { length: numRows },
+          (_, i) => `Record_${i}`
+        );
+        const fullString = strings.join('');
+        const stringBytes = new TextEncoder().encode(fullString);
+        const stringOffsets = new BigUint64Array(numRows);
+        let offset = 0;
+        for (let i = 0; i < numRows; i++) {
+          stringOffsets[i] = BigInt(offset);
+          offset += new TextEncoder().encode(strings[i]).length;
+        }
+        const stringOffsetsBytes = numRows * 8;
+        const stringDataBytes = stringBytes.length;
+        const stringValidityBytes = numRows;
+
+        // 3. Nullable floats
+        const floatsBytes = numRows * 8; // Float64
+        const floatsData = new Float64Array(numRows);
+        const floatsValidityBytes = numRows;
+        const floatsValidity = new Uint8Array(floatsValidityBytes);
+        for (let i = 0; i < numRows; i++) {
+          floatsData[i] = Math.random() * 1000;
+          floatsValidity[i] = i % 10 === 0 ? 0 : 1; // 10% null
+        }
+
+        // Calculate padding needed for Float64Array alignment (must be multiple of 8)
+        const beforeFloatOffset = 
+          rowsBytes + 
+          stringOffsetsBytes + 
+          stringDataBytes + 
+          stringValidityBytes;
+        const paddingBytes = (8 - (beforeFloatOffset % 8)) % 8;
+
+        // Calculate total buffer size
+        const totalBytes =
+          rowsBytes +
+          stringOffsetsBytes +
+          stringDataBytes +
+          stringValidityBytes +
+          paddingBytes +
+          floatsBytes +
+          floatsValidityBytes;
+
+        const buffer = new ArrayBuffer(totalBytes);
+        let currentOffset = 0;
+
+        // Write rows
+        new Int32Array(buffer, currentOffset, numRows).set(rowsData);
+        currentOffset += rowsBytes;
+
+        // Write string offsets
+        new BigUint64Array(buffer, currentOffset, numRows).set(stringOffsets);
+        currentOffset += stringOffsetsBytes;
+
+        // Write string data
+        new Uint8Array(buffer, currentOffset, stringBytes.length).set(
+          stringBytes
+        );
+        currentOffset += stringDataBytes;
+
+        // Write string validity
+        new Uint8Array(buffer, currentOffset, stringValidityBytes).fill(1);
+        currentOffset += stringValidityBytes;
+
+        // Add padding
+        currentOffset += paddingBytes;
+
+        // Write floats (now properly aligned)
+        new Float64Array(buffer, currentOffset, numRows).set(floatsData);
+        currentOffset += floatsBytes;
+
+        // Write float validity
+        new Uint8Array(buffer, currentOffset, floatsValidityBytes).set(
+          floatsValidity
+        );
+
+        const bufferHeaders = [
+          {
+            name: 'rows',
+            fixedLenBufferSizeInBytes: rowsBytes,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: rowsBytes,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'names',
+            fixedLenBufferSizeInBytes: stringOffsetsBytes,
+            varLenBufferSizeInBytes: stringDataBytes,
+            validityLenBufferSizeInBytes: stringValidityBytes,
+            originalFixedLenBufferSizeInBytes: stringOffsetsBytes,
+            originalVarLenBufferSizeInBytes: stringDataBytes,
+            originalValidityLenBufferSizeInBytes: stringValidityBytes
+          },
+          {
+            name: 'values',
+            fixedLenBufferSizeInBytes: floatsBytes,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: floatsValidityBytes,
+            originalFixedLenBufferSizeInBytes: floatsBytes,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: floatsValidityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            name: 'rows',
+            nullTileExtent: false,
+            type: Datatype.Int32,
+            tileExtent: { int32: 4 },
+            domain: { int32: [] },
+            filterPipeline: {}
+          },
+          {
+            cellValNum: 4294967295,
+            name: 'names',
+            type: Datatype.StringUtf8,
+            filterPipeline: {},
+            fillValue: [0],
+            nullable: true,
+            fillValueValidity: false
+          },
+          {
+            cellValNum: 1,
+            name: 'values',
+            type: Datatype.Float64,
+            filterPipeline: {},
+            fillValue: [0, 0, 0, 0, 0, 0, 0, 0],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema
+        );
+        const endTime = performance.now();
+
+        expect((results.rows as number[]).length).toBe(numRows);
+        expect((results.names as string[]).length).toBe(numRows);
+        expect((results.values as Array<number | null>).length).toBe(numRows);
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Mixed workload (${numRows} rows, 3 different attribute types): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        expect(elapsedTime).toBeLessThan(10000); // 10 seconds max
+      },
+      30000
+    );
   });
 });

--- a/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
+++ b/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
@@ -769,4 +769,418 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
       30000
     );
   });
+
+  describe('Big data var-length attributes performance (100K scale)', () => {
+    it(
+      'Should handle 100K var-length nullable strings efficiently',
+      async () => {
+        const numStrings = 100000;
+        const encoder = new TextEncoder();
+
+        // Generate strings with varying lengths (5-50 chars)
+        const strings: string[] = new Array(numStrings);
+        for (let i = 0; i < numStrings; i++) {
+          const len = 5 + (i % 46); // lengths from 5 to 50
+          strings[i] = `s${i}_${'a'.repeat(len)}`;
+        }
+
+        // Encode all strings and compute byte offsets
+        const encodedStrings = strings.map(s => encoder.encode(s));
+        const offsets = new BigUint64Array(numStrings);
+        let totalStringBytes = 0;
+        for (let i = 0; i < numStrings; i++) {
+          offsets[i] = BigInt(totalStringBytes);
+          totalStringBytes += encodedStrings[i].length;
+        }
+
+        const offsetsBytes = numStrings * 8;
+        const validityBytes = numStrings;
+        const totalBytes = offsetsBytes + totalStringBytes + validityBytes;
+
+        const buffer = new ArrayBuffer(totalBytes);
+
+        // Write offsets
+        new BigUint64Array(buffer, 0, numStrings).set(offsets);
+
+        // Write string data
+        const stringDataView = new Uint8Array(buffer, offsetsBytes, totalStringBytes);
+        let writePos = 0;
+        for (let i = 0; i < numStrings; i++) {
+          stringDataView.set(encodedStrings[i], writePos);
+          writePos += encodedStrings[i].length;
+        }
+
+        // Write validity — 15% null
+        const validityView = new Uint8Array(
+          buffer,
+          offsetsBytes + totalStringBytes,
+          validityBytes
+        );
+        for (let i = 0; i < numStrings; i++) {
+          validityView[i] = i % 7 === 0 ? 0 : 1;
+        }
+
+        const bufferHeaders = [
+          {
+            name: 'labels',
+            fixedLenBufferSizeInBytes: offsetsBytes,
+            varLenBufferSizeInBytes: totalStringBytes,
+            validityLenBufferSizeInBytes: validityBytes,
+            originalFixedLenBufferSizeInBytes: offsetsBytes,
+            originalVarLenBufferSizeInBytes: totalStringBytes,
+            originalValidityLenBufferSizeInBytes: validityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            cellValNum: 4294967295,
+            name: 'labels',
+            type: Datatype.StringUtf8,
+            filterPipeline: {},
+            fillValue: [0],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema
+        );
+        const endTime = performance.now();
+
+        const labels = results.labels as Array<string | null>;
+        expect(labels.length).toBe(numStrings);
+
+        // Verify a sample of non-null values
+        expect(labels[1]).toBe(strings[1]);
+        expect(labels[10]).toBe(strings[10]);
+        expect(labels[99999]).toBe(strings[99999]);
+
+        // Verify nulls are applied correctly
+        expect(labels[0]).toBeNull();
+        expect(labels[7]).toBeNull();
+        expect(labels[14]).toBeNull();
+        expect(labels[1]).not.toBeNull();
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Big data var-length strings (${numStrings} strings, ~${(totalStringBytes / numStrings).toFixed(0)} avg bytes, 15% null): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        expect(elapsedTime).toBeLessThan(5000);
+      },
+      30000
+    );
+
+    it(
+      'Should handle 100K var-length numeric arrays with variable sizes efficiently',
+      async () => {
+        const numArrays = 100000;
+
+        // Pre-calculate total values so we can allocate upfront
+        const arraySizes = new Array(numArrays);
+        let totalValues = 0;
+        for (let i = 0; i < numArrays; i++) {
+          // Varying sizes: 1 to 20 elements per cell
+          arraySizes[i] = 1 + (i % 20);
+          totalValues += arraySizes[i];
+        }
+
+        const offsetsBytes = numArrays * 8;
+        const bytesPerElement = 4; // Int32
+        const valuesBytes = totalValues * bytesPerElement;
+        const validityBytes = numArrays;
+        const totalBytes = offsetsBytes + valuesBytes + validityBytes;
+
+        const buffer = new ArrayBuffer(totalBytes);
+
+        // Write offsets (byte offsets for Int32 values)
+        const offsetView = new BigUint64Array(buffer, 0, numArrays);
+        let byteOffset = 0;
+        for (let i = 0; i < numArrays; i++) {
+          offsetView[i] = BigInt(byteOffset);
+          byteOffset += arraySizes[i] * bytesPerElement;
+        }
+
+        // Write values
+        const valuesView = new Int32Array(buffer, offsetsBytes, totalValues);
+        let valIdx = 0;
+        for (let i = 0; i < numArrays; i++) {
+          for (let j = 0; j < arraySizes[i]; j++) {
+            valuesView[valIdx++] = i * 100 + j;
+          }
+        }
+
+        // Write validity — 10% null
+        const validityView = new Uint8Array(
+          buffer,
+          offsetsBytes + valuesBytes,
+          validityBytes
+        );
+        for (let i = 0; i < numArrays; i++) {
+          validityView[i] = i % 10 === 0 ? 0 : 1;
+        }
+
+        const bufferHeaders = [
+          {
+            name: 'vectors',
+            fixedLenBufferSizeInBytes: offsetsBytes,
+            varLenBufferSizeInBytes: valuesBytes,
+            validityLenBufferSizeInBytes: validityBytes,
+            originalFixedLenBufferSizeInBytes: offsetsBytes,
+            originalVarLenBufferSizeInBytes: valuesBytes,
+            originalValidityLenBufferSizeInBytes: validityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            cellValNum: 4294967295,
+            name: 'vectors',
+            type: Datatype.Int32,
+            filterPipeline: {},
+            fillValue: [0, 0, 0, 128],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema
+        );
+        const endTime = performance.now();
+
+        const vectors = results.vectors as Array<number[] | null>;
+        expect(vectors.length).toBe(numArrays);
+
+        // Verify null entries
+        expect(vectors[0]).toBeNull();
+        expect(vectors[10]).toBeNull();
+        expect(vectors[1]).not.toBeNull();
+
+        // Verify a non-null array has the correct length and first value
+        expect(vectors[1]!.length).toBe(arraySizes[1]);
+        expect(vectors[1]![0]).toBe(100);
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Big data var-length Int32 arrays (${numArrays} arrays, ${totalValues} total values, avg ${(totalValues / numArrays).toFixed(1)} per cell): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        expect(elapsedTime).toBeLessThan(10000);
+      },
+      30000
+    );
+
+    it(
+      'Should handle 100K rows with multiple var-length attributes combined',
+      async () => {
+        const numRows = 100000;
+        const encoder = new TextEncoder();
+
+        // --- Dimension: rows (fixed Int32) ---
+        const rowsBytes = numRows * 4;
+
+        // --- Attribute 1: var-length nullable strings ---
+        const strings: string[] = new Array(numRows);
+        for (let i = 0; i < numRows; i++) {
+          strings[i] = `item_${i}_${'z'.repeat(i % 30)}`;
+        }
+        const encodedStrings = strings.map(s => encoder.encode(s));
+        const strOffsets = new BigUint64Array(numRows);
+        let totalStrBytes = 0;
+        for (let i = 0; i < numRows; i++) {
+          strOffsets[i] = BigInt(totalStrBytes);
+          totalStrBytes += encodedStrings[i].length;
+        }
+        const strOffsetsBytes = numRows * 8;
+        const strValidityBytes = numRows;
+
+        // --- Attribute 2: var-length nullable Int32 arrays ---
+        const arraySizes = new Array(numRows);
+        let totalInts = 0;
+        for (let i = 0; i < numRows; i++) {
+          arraySizes[i] = 1 + (i % 10);
+          totalInts += arraySizes[i];
+        }
+        const intOffsetsBytes = numRows * 8;
+        const intBytesPerElement = 4;
+        const intValuesBytes = totalInts * intBytesPerElement;
+        const intValidityBytes = numRows;
+
+        // Compute total buffer: rows + strOffsets + strData + strValidity + intOffsets + intValues + intValidity
+        // Need to ensure BigUint64Array alignment for intOffsets
+        const afterStrValidity = rowsBytes + strOffsetsBytes + totalStrBytes + strValidityBytes;
+        const intOffsetsPadding = (8 - (afterStrValidity % 8)) % 8;
+
+        const totalBytes =
+          rowsBytes +
+          strOffsetsBytes + totalStrBytes + strValidityBytes +
+          intOffsetsPadding +
+          intOffsetsBytes + intValuesBytes + intValidityBytes;
+
+        const buffer = new ArrayBuffer(totalBytes);
+        let pos = 0;
+
+        // Write rows
+        const rowsView = new Int32Array(buffer, pos, numRows);
+        for (let i = 0; i < numRows; i++) rowsView[i] = i;
+        pos += rowsBytes;
+
+        // Write string offsets
+        new BigUint64Array(buffer, pos, numRows).set(strOffsets);
+        pos += strOffsetsBytes;
+
+        // Write string data
+        const strDataView = new Uint8Array(buffer, pos, totalStrBytes);
+        let strWritePos = 0;
+        for (let i = 0; i < numRows; i++) {
+          strDataView.set(encodedStrings[i], strWritePos);
+          strWritePos += encodedStrings[i].length;
+        }
+        pos += totalStrBytes;
+
+        // Write string validity — 20% null
+        const strValidityView = new Uint8Array(buffer, pos, strValidityBytes);
+        for (let i = 0; i < numRows; i++) {
+          strValidityView[i] = i % 5 === 0 ? 0 : 1;
+        }
+        pos += strValidityBytes;
+
+        // Padding for alignment
+        pos += intOffsetsPadding;
+
+        // Write int array offsets (byte offsets)
+        const intOffsetsView = new BigUint64Array(buffer, pos, numRows);
+        let intByteOff = 0;
+        for (let i = 0; i < numRows; i++) {
+          intOffsetsView[i] = BigInt(intByteOff);
+          intByteOff += arraySizes[i] * intBytesPerElement;
+        }
+        pos += intOffsetsBytes;
+
+        // Write int values
+        const intValuesView = new Int32Array(buffer, pos, totalInts);
+        let intIdx = 0;
+        for (let i = 0; i < numRows; i++) {
+          for (let j = 0; j < arraySizes[i]; j++) {
+            intValuesView[intIdx++] = i + j;
+          }
+        }
+        pos += intValuesBytes;
+
+        // Write int validity — 25% null
+        const intValidityView = new Uint8Array(buffer, pos, intValidityBytes);
+        for (let i = 0; i < numRows; i++) {
+          intValidityView[i] = i % 4 === 0 ? 0 : 1;
+        }
+
+        const bufferHeaders = [
+          {
+            name: 'rows',
+            fixedLenBufferSizeInBytes: rowsBytes,
+            varLenBufferSizeInBytes: 0,
+            validityLenBufferSizeInBytes: 0,
+            originalFixedLenBufferSizeInBytes: rowsBytes,
+            originalVarLenBufferSizeInBytes: 0,
+            originalValidityLenBufferSizeInBytes: 0
+          },
+          {
+            name: 'labels',
+            fixedLenBufferSizeInBytes: strOffsetsBytes,
+            varLenBufferSizeInBytes: totalStrBytes,
+            validityLenBufferSizeInBytes: strValidityBytes + intOffsetsPadding,
+            originalFixedLenBufferSizeInBytes: strOffsetsBytes,
+            originalVarLenBufferSizeInBytes: totalStrBytes,
+            originalValidityLenBufferSizeInBytes: strValidityBytes + intOffsetsPadding
+          },
+          {
+            name: 'data',
+            fixedLenBufferSizeInBytes: intOffsetsBytes,
+            varLenBufferSizeInBytes: intValuesBytes,
+            validityLenBufferSizeInBytes: intValidityBytes,
+            originalFixedLenBufferSizeInBytes: intOffsetsBytes,
+            originalVarLenBufferSizeInBytes: intValuesBytes,
+            originalValidityLenBufferSizeInBytes: intValidityBytes
+          }
+        ];
+
+        const schema = [
+          {
+            name: 'rows',
+            nullTileExtent: false,
+            type: Datatype.Int32,
+            tileExtent: { int32: 4 },
+            domain: { int32: [] },
+            filterPipeline: {}
+          },
+          {
+            cellValNum: 4294967295,
+            name: 'labels',
+            type: Datatype.StringUtf8,
+            filterPipeline: {},
+            fillValue: [0],
+            nullable: true,
+            fillValueValidity: false
+          },
+          {
+            cellValNum: 4294967295,
+            name: 'data',
+            type: Datatype.Int32,
+            filterPipeline: {},
+            fillValue: [0, 0, 0, 128],
+            nullable: true,
+            fillValueValidity: false
+          }
+        ];
+
+        const startTime = performance.now();
+        const results = await getResultsFromArrayBuffer(
+          new DataView(buffer),
+          bufferHeaders,
+          schema
+        );
+        const endTime = performance.now();
+
+        const rows = results.rows as number[];
+        const labels = results.labels as Array<string | null>;
+        const data = results.data as Array<number[] | null>;
+
+        expect(rows.length).toBe(numRows);
+        expect(labels.length).toBe(numRows);
+        expect(data.length).toBe(numRows);
+
+        // Spot-check rows
+        expect(rows[0]).toBe(0);
+        expect(rows[numRows - 1]).toBe(numRows - 1);
+
+        // Spot-check string nulls (every 5th)
+        expect(labels[0]).toBeNull();
+        expect(labels[5]).toBeNull();
+        expect(labels[1]).toBe(strings[1]);
+
+        // Spot-check int array nulls (every 4th) and values
+        expect(data[0]).toBeNull();
+        expect(data[4]).toBeNull();
+        expect(data[1]).not.toBeNull();
+        expect(data[1]!.length).toBe(arraySizes[1]);
+        expect(data[1]![0]).toBe(1);
+
+        const elapsedTime = endTime - startTime;
+        console.log(
+          `Big data multi-attribute (${numRows} rows: fixed dim + var-len strings + var-len Int32[], 20%/25% null): ${elapsedTime.toFixed(2)}ms`
+        );
+
+        expect(elapsedTime).toBeLessThan(10000);
+      },
+      30000
+    );
+  });
 });

--- a/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
+++ b/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.test.ts
@@ -13,6 +13,33 @@ import {
 import { describe, it, expect } from 'vitest';
 import { Datatype } from '../../v3';
 
+/**
+ * Helper to capture memory metrics
+ */
+interface MemoryMetrics {
+  heapUsedMB: number;
+  heapTotalMB: number;
+  externalMB: number;
+  rss: number;
+}
+
+function getMemoryMetrics(): MemoryMetrics {
+  const mem = process.memoryUsage();
+  return {
+    heapUsedMB: mem.heapUsed / 1024 / 1024,
+    heapTotalMB: mem.heapTotal / 1024 / 1024,
+    externalMB: mem.external / 1024 / 1024,
+    rss: mem.rss / 1024 / 1024
+  };
+}
+
+function formatMemoryDelta(before: MemoryMetrics, after: MemoryMetrics): string {
+  const heapDelta = after.heapUsedMB - before.heapUsedMB;
+  const externalDelta = after.externalMB - before.externalMB;
+  const rssDelta = after.rss - before.rss;
+  return `Heap: ${heapDelta >= 0 ? '+' : ''}${heapDelta.toFixed(2)}MB, External: ${externalDelta >= 0 ? '+' : ''}${externalDelta.toFixed(2)}MB, RSS: ${rssDelta >= 0 ? '+' : ''}${rssDelta.toFixed(2)}MB`;
+}
+
 describe('getResultsFromArrayBuffer()', () => {
   it('Should convert a raw ArrayBuffer to a results object with fixed length attributes', async () => {
     const file = path.join(__dirname, '../../fixtures/fixed_buffer.raw');
@@ -107,6 +134,8 @@ describe('getResultsFromArrayBuffer()', () => {
       }
     ];
 
+    const memBefore = getMemoryMetrics();
+    const startTime = performance.now();
     const results = await getResultsFromArrayBuffer(
       arrayBufferOfFixedLengthAttributes,
       attributeBufferHeaders,
@@ -115,8 +144,16 @@ describe('getResultsFromArrayBuffer()', () => {
         returnRawBuffers: true
       }
     );
+    const endTime = performance.now();
+    const memAfter = getMemoryMetrics();
 
     expect(results).toEqual({ cols: new ArrayBuffer(0) });
+
+    const elapsedTime = endTime - startTime;
+    console.log(
+      `returnRawBuffers (${attributeBufferHeaders.length} attributes): ${elapsedTime.toFixed(2)}ms`
+    );
+    console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
   });
 });
 
@@ -178,6 +215,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -185,6 +223,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           fixedLenAttributesSchema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         expect(Object.keys(results)).toHaveLength(4);
         expect((results.cols as number[]).length).toBe(numElements);
@@ -196,6 +235,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Fixed-length processing (${numElements} elements): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         // Performance assertion - should complete in reasonable time
         expect(elapsedTime).toBeLessThan(5000); // 5 seconds max
@@ -256,6 +296,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -264,6 +305,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           { returnRawBuffers: true }
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         expect(results.cols).toBeInstanceOf(ArrayBuffer);
         expect((results.cols as ArrayBuffer).byteLength).toBe(
@@ -274,6 +316,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `returnRawBuffers (${numElements} elements): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         // Raw buffers should be much faster as no conversion happens
         expect(elapsedTime).toBeLessThan(1000); // 1 second max
@@ -352,6 +395,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -359,6 +403,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           schema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         expect((results.strings as string[]).length).toBe(numStrings);
         expect((results.strings as string[])[0]).toBe(strings[0]);
@@ -367,6 +412,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Var-length strings (${numStrings} strings, avg ${avgStringLength} chars): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         expect(elapsedTime).toBeLessThan(10000); // 10 seconds max
       },
@@ -439,6 +485,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -446,6 +493,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           schema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         expect((results.arrays as number[][]).length).toBe(numArrays);
 
@@ -453,6 +501,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Var-length numeric arrays (${numArrays} arrays, ${totalValues} total values): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         expect(elapsedTime).toBeLessThan(15000); // 15 seconds max
       },
@@ -504,6 +553,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -511,6 +561,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           schema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         expect((results.nullable_data as Array<number | null>).length).toBe(
           numElements
@@ -520,6 +571,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Nullable attributes (${numElements} elements, ~20% null): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         expect(elapsedTime).toBeLessThan(5000); // 5 seconds max
       },
@@ -568,6 +620,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -576,6 +629,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           { ignoreNullables: true }
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         // With ignoreNullables, no nulls should be in result
         expect((results.nullable_data as number[]).every(v => v !== null)).toBe(
@@ -586,6 +640,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Nullable ignored (${numElements} elements): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         // Should be faster than processing nullables
         expect(elapsedTime).toBeLessThan(3000); // 3 seconds max
@@ -747,6 +802,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -754,6 +810,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           schema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         expect((results.rows as number[]).length).toBe(numRows);
         expect((results.names as string[]).length).toBe(numRows);
@@ -763,6 +820,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Mixed workload (${numRows} rows, 3 different attribute types): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         expect(elapsedTime).toBeLessThan(10000); // 10 seconds max
       },
@@ -844,6 +902,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -851,6 +910,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           schema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         const labels = results.labels as Array<string | null>;
         expect(labels.length).toBe(numStrings);
@@ -870,6 +930,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Big data var-length strings (${numStrings} strings, ~${(totalStringBytes / numStrings).toFixed(0)} avg bytes, 15% null): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         expect(elapsedTime).toBeLessThan(5000);
       },
@@ -949,6 +1010,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -956,6 +1018,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           schema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         const vectors = results.vectors as Array<number[] | null>;
         expect(vectors.length).toBe(numArrays);
@@ -973,6 +1036,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Big data var-length Int32 arrays (${numArrays} arrays, ${totalValues} total values, avg ${(totalValues / numArrays).toFixed(1)} per cell): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         expect(elapsedTime).toBeLessThan(10000);
       },
@@ -1141,6 +1205,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           }
         ];
 
+        const memBefore = getMemoryMetrics();
         const startTime = performance.now();
         const results = await getResultsFromArrayBuffer(
           new DataView(buffer),
@@ -1148,6 +1213,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
           schema
         );
         const endTime = performance.now();
+        const memAfter = getMemoryMetrics();
 
         const rows = results.rows as number[];
         const labels = results.labels as Array<string | null>;
@@ -1177,6 +1243,7 @@ describe('getResultsFromArrayBuffer() - Performance Tests', () => {
         console.log(
           `Big data multi-attribute (${numRows} rows: fixed dim + var-len strings + var-len Int32[], 20%/25% null): ${elapsedTime.toFixed(2)}ms`
         );
+        console.log(`  Memory: ${formatMemoryDelta(memBefore, memAfter)}`);
 
         expect(elapsedTime).toBeLessThan(10000);
       },

--- a/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.ts
+++ b/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.ts
@@ -57,6 +57,25 @@ type Result =
 type Results = Record<string, Result>;
 type DataMap = { __offsets?: Record<string, bigint[]> };
 
+const stringTypes: Set<Datatype> = new Set([
+  Datatype.Char,
+  Datatype.StringAscii,
+  Datatype.StringUtf8,
+  Datatype.StringUtf16,
+  Datatype.StringUtf32,
+  Datatype.StringUcs2,
+  Datatype.StringUcs4
+]);
+
+const stringDecoderMap: Partial<Record<Datatype, string>> = {
+  [Datatype.Char]: 'utf-8',
+  [Datatype.StringAscii]: 'ascii',
+  [Datatype.StringUtf8]: 'utf-8',
+  [Datatype.StringUtf16]: 'utf-16',
+  [Datatype.StringUcs2]: 'utf-16',
+  // StringUtf32 and StringUcs4 are not natively supported by TextDecoder
+};
+
 /**
  * Convert an ArrayBuffer to a map of attributes with their results
  * @param arrayBuffer The slice ArrayBuffer that contains the results
@@ -76,9 +95,10 @@ export const getResultsFromArrayBuffer = async (
     data.__offsets = {};
   }
 
-  await attributeBufferHeaders.reduce(async (_byteOffset, attribute) => {
+  let byteOffset = 0;
+
+  for (const attribute of attributeBufferHeaders) {
     const totalNumberOfBytesOfAttribute = getAttributeSizeInBytes(attribute);
-    const byteOffset = await _byteOffset;
 
     if (!totalNumberOfBytesOfAttribute) {
       if (options.returnRawBuffers) {
@@ -87,7 +107,7 @@ export const getResultsFromArrayBuffer = async (
         data[attribute.name] = [];
       }
 
-      return byteOffset;
+      continue;
     }
 
     // If there are validityLenBufferSizeInBytes the attribute is nullable
@@ -105,16 +125,6 @@ export const getResultsFromArrayBuffer = async (
     const validityOffset =
       totalNumberOfBytesOfAttribute -
       (isNullable ? attribute.validityLenBufferSizeInBytes : 0);
-    /**
-     * If attribute is varLengthSized, we ignore the first N bytes (where N = fixedLenBufferSizeInBytes)
-     * These first N bytes contain the offsets of the attribute, which is a uint64 array.
-     */
-
-    /**
-     * If attribute is isNullable we ignore the last N bytes (where N = validityLenBufferSizeInBytes)
-     * These last N bytes contain a uint8 array of zeros and ones, where every zero represents
-     * that in that index the attribute is null.
-     */
 
     /**
      * Offsets are Uint64 numbers, buffer contains byte offsets though,
@@ -131,13 +141,21 @@ export const getResultsFromArrayBuffer = async (
         BigUint64Array.BYTES_PER_ELEMENT
       );
 
-      byteOffsets = Array.from(
-        new BigUint64Array(
-          buffer,
-          offset,
-          attribute.fixedLenBufferSizeInBytes / BigUint64Array.BYTES_PER_ELEMENT
-        )
+      const offsetCount =
+        attribute.fixedLenBufferSizeInBytes /
+        BigUint64Array.BYTES_PER_ELEMENT;
+
+      // Read offsets directly from DataView to avoid materializing a BigInt array
+      // when we only need them as numbers later. Keep bigint array for returnOffsets.
+      const alignedView = new DataView(
+        buffer,
+        offset,
+        attribute.fixedLenBufferSizeInBytes
       );
+      byteOffsets = new Array(offsetCount);
+      for (let i = 0; i < offsetCount; i++) {
+        byteOffsets[i] = alignedView.getBigUint64(i * 8, true);
+      }
 
       if (options.returnOffsets) {
         data.__offsets[attribute.name] = byteOffsets;
@@ -150,28 +168,81 @@ export const getResultsFromArrayBuffer = async (
         arrayBuffer.byteOffset + byteOffset + validityOffset
       );
 
-      return byteOffset + totalNumberOfBytesOfAttribute;
+      byteOffset += totalNumberOfBytesOfAttribute;
+      continue;
+    }
+
+    const dataStart = arrayBuffer.byteOffset + byteOffset + dataOffset;
+    const dataLength = validityOffset - dataOffset;
+
+    // Fast path for var-length string types: decode sub-buffers directly
+    // instead of decode→split→group→join
+    if (
+      isVarLengthSized &&
+      !options.ignoreOffsets &&
+      stringTypes.has(selectedAttributeSchema.type) &&
+      selectedAttributeSchema.type !== Datatype.StringUtf32 &&
+      selectedAttributeSchema.type !== Datatype.StringUcs4
+    ) {
+      const encoding =
+        stringDecoderMap[selectedAttributeSchema.type] || 'utf-8';
+      const decoder = new TextDecoder(encoding);
+      const numStrings = byteOffsets.length;
+      const strings: string[] = new Array(numStrings);
+
+      for (let i = 0; i < numStrings; i++) {
+        const start = Number(byteOffsets[i]);
+        const end =
+          i + 1 < numStrings ? Number(byteOffsets[i + 1]) : dataLength;
+        strings[i] = decoder.decode(
+          new Uint8Array(arrayBuffer.buffer, dataStart + start, end - start)
+        );
+      }
+
+      let result: Result = strings;
+
+      if (isNullable && !options.ignoreNullables) {
+        const nullablesTypedArray = bufferToInt8(
+          new DataView(
+            arrayBuffer.buffer,
+            arrayBuffer.byteOffset + byteOffset + validityOffset,
+            totalNumberOfBytesOfAttribute - validityOffset
+          )
+        );
+        const nullablesArray: number[] = new Array(nullablesTypedArray.length);
+        for (let i = 0; i < nullablesTypedArray.length; i++) {
+          nullablesArray[i] = nullablesTypedArray[i];
+        }
+        result = setNullables(strings, nullablesArray);
+      }
+
+      data[attribute.name] = result;
+      byteOffset += totalNumberOfBytesOfAttribute;
+      continue;
     }
 
     let result: Result = getAttributeResult(
       new DataView(
         arrayBuffer.buffer,
-        arrayBuffer.byteOffset + byteOffset + dataOffset,
-        validityOffset - dataOffset
+        dataStart,
+        dataLength
       ),
       selectedAttributeSchema.type
     );
 
-    let offsets: number[] = [];
     if (isVarLengthSized && !options.ignoreOffsets) {
       const BYTE_PER_ELEMENT = BigInt(
         getByteLengthOfDatatype(selectedAttributeSchema.type)
       );
 
-      // Convert byte offsets to offsets
-      offsets = byteOffsets.map(o => Number(o / BYTE_PER_ELEMENT));
+      // Convert byte offsets to element offsets
+      const offsets: number[] = new Array(byteOffsets.length);
+      for (let i = 0; i < byteOffsets.length; i++) {
+        offsets[i] = Number(byteOffsets[i] / BYTE_PER_ELEMENT);
+      }
+
       const isString = typeof result === 'string';
-      const groupedValues = await groupValuesByOffsetBytes(
+      const groupedValues = groupValuesByOffsetBytes(
         convertToArray(result) as Array<unknown>,
         offsets
       );
@@ -181,11 +252,6 @@ export const getResultsFromArrayBuffer = async (
         ? concatChars(groupedValues as string[][])
         : (groupedValues as number[][] | bigint[][]);
 
-      /**
-       * ParallelJS accepts data that are JSON serializable
-       * thus we have to convert buffer to array of uint8
-       * and after grouping convert the data back to ArrayBuffer.
-       */
       if (selectedAttributeSchema.type === Datatype.Blob) {
         const arrayBuffers = groupedValues.map(
           ints => Uint8Array.from(ints).buffer
@@ -210,7 +276,10 @@ export const getResultsFromArrayBuffer = async (
        * nullablesArray should be an array of zeros and ones (e.g. [0, 1, 1, 0])
        * Every zero represents that in that specific index the attribute is NULL
        */
-      const nullablesArray = Array.from(nullablesTypedArray);
+      const nullablesArray: number[] = new Array(nullablesTypedArray.length);
+      for (let i = 0; i < nullablesTypedArray.length; i++) {
+        nullablesArray[i] = nullablesTypedArray[i];
+      }
 
       // @ts-expect-error: Cannot infer a single T that satisfies all Array<...>
       result = setNullables(result, nullablesArray);
@@ -218,152 +287,8 @@ export const getResultsFromArrayBuffer = async (
 
     data[attribute.name] = result;
 
-    return byteOffset + totalNumberOfBytesOfAttribute;
-  }, Promise.resolve(0));
-
-  // await attributeBufferHeaders
-  //   .reverse()
-  //   .reduce(async (offsetPromise, attribute) => {
-  //     const totalNumberOfBytesOfAttribute = getAttributeSizeInBytes(attribute);
-  //     const offset = await offsetPromise;
-
-  //     if (!totalNumberOfBytesOfAttribute) {
-  //       if (options.returnRawBuffers) {
-  //         data[attribute.name] = new ArrayBuffer(0);
-  //       } else {
-  //         data[attribute.name] = [];
-  //       }
-
-  //       return offset;
-  //     }
-
-  //     // If there are validityLenBufferSizeInBytes the attribute is nullable
-  //     const isNullable = !!attribute.validityLenBufferSizeInBytes;
-  //     // If there are varLenBufferSizeInBytes the attribute is varLengthSized
-  //     const isVarLengthSized = !!attribute.varLenBufferSizeInBytes;
-  //     const selectedAttributeSchema = getAttributeSchema(
-  //       attribute.name,
-  //       attributesSchema
-  //     );
-
-  //     const negativeOffset = -1 * offset;
-  //     /**
-  //      * If attribute is varLengthSized, we ignore the first N bytes (where N = fixedLenBufferSizeInBytes)
-  //      * These first N bytes contain the offsets of the attribute, which is a uint64 array.
-  //      */
-  //     const start =
-  //       negativeOffset -
-  //       totalNumberOfBytesOfAttribute +
-  //       (isVarLengthSized ? attribute.fixedLenBufferSizeInBytes : 0);
-  //     /**
-  //      * If attribute is isNullable we ignore the last N bytes (where N = validityLenBufferSizeInBytes)
-  //      * These last N bytes contain a uint8 array of zeros and ones, where every zero represents
-  //      * that in that index the attribute is null.
-  //      */
-  //     const ending =
-  //       negativeOffset -
-  //       (isNullable ? attribute.validityLenBufferSizeInBytes : 0);
-  //     const end = ending ? ending : undefined;
-  //     /**
-  //      * Offsets are Uint64 numbers, buffer contains byte offsets though,
-  //      * e.g. if type of the attribute is an INT32 (4 bytes per number) and the offsets are [0, 3, 4]
-  //      * the buffer contains the offsets * bytes of the element instead of just the offsets [0, 3 * 4, 4 * 4] = [0, 12, 16]
-  //      */
-  //     let byteOffsets: bigint[] = [];
-
-  //     if (isVarLengthSized) {
-  //       const startOfBuffer = negativeOffset - totalNumberOfBytesOfAttribute;
-  //       const offsetsBuffer = arrayBuffer.slice(
-  //         startOfBuffer,
-  //         startOfBuffer + attribute.fixedLenBufferSizeInBytes
-  //       );
-
-  //       byteOffsets = Array.from(
-  //         new BigUint64Array(
-  //           arrayBuffer.buffer,
-  //           arrayBuffer.byteOffset + startOfBuffer,
-  //           attribute.fixedLenBufferSizeInBytes
-  //         )
-  //       );
-  //     }
-
-  //     if (isVarLengthSized && options.returnOffsets) {
-  //       data.__offsets[attribute.name] = byteOffsets;
-  //     }
-
-  //     if (options.returnRawBuffers) {
-  //       data[attribute.name] = arrayBuffer.slice(start, end);
-
-  //       return offset + totalNumberOfBytesOfAttribute;
-  //     }
-
-  //     let result: Result = getAttributeResult(
-  //       arrayBuffer.slice(start, end),
-  //       selectedAttributeSchema.type
-  //     ) as string | number[] | bigint[];
-  //     let offsets: number[] = [];
-  //     if (isVarLengthSized && !options.ignoreOffsets) {
-  //       const BYTE_PER_ELEMENT = getByteLengthOfDatatype(
-  //         selectedAttributeSchema.type
-  //       );
-
-  //       // Convert byte offsets to offsets
-  //       offsets = byteOffsets.map(o => Number(o / BigInt(BYTE_PER_ELEMENT)));
-  //       const isString = typeof result === 'string';
-  //       const groupedValues = await groupValuesByOffsetBytes(
-  //         convertToArray(result),
-  //         offsets
-  //       );
-
-  //       // If it's a string we concat all the characters to create array of strings
-  //       result = isString
-  //         ? concatChars(groupedValues as string[][])
-  //         : (groupedValues as number[][] | bigint[][]);
-
-  //       /**
-  //        * ParallelJS accepts data that are JSON serializable
-  //        * thus we have to convert buffer to array of uint8
-  //        * and after grouping convert the data back to ArrayBuffer.
-  //        */
-  //       if (selectedAttributeSchema.type === Datatype.Blob) {
-  //         const arrayBuffers = groupedValues.map(
-  //           ints => Uint8Array.from(ints).buffer
-  //         );
-  //         result = arrayBuffers;
-  //       }
-  //     }
-
-  //     if (isNullable && !options.ignoreNullables) {
-  //       /**
-  //        * If attribute is Nullable, we get the last N bytes, cast it to uint8 array to get
-  //        * what is null.
-  //        */
-  //       const nullableArrayEnd =
-  //         ending + attribute.validityLenBufferSizeInBytes;
-  //       const nullableArrayBuffer = arrayBuffer.slice(
-  //         ending,
-  //         nullableArrayEnd ? nullableArrayEnd : undefined
-  //       );
-  //       const nullablesTypedArray = bufferToInt8(nullableArrayBuffer);
-  //       /**
-  //        * nullablesArray should be an array of zeros and ones (e.g. [0, 1, 1, 0])
-  //        * Every zero represents that in that specific index the attribute is NULL
-  //        */
-  //       const nullablesArray = Array.from(nullablesTypedArray);
-  //       const values = convertToArray(result) as Array<
-  //         string | bigint | number
-  //       >;
-
-  //       result = (await setNullables(values, nullablesArray)) as
-  //         | number[]
-  //         | string[]
-  //         | bigint[];
-  //     }
-
-  //     data[attribute.name] = result;
-
-  //     return offset + totalNumberOfBytesOfAttribute;
-  //   }, Promise.resolve(0));
+    byteOffset += totalNumberOfBytesOfAttribute;
+  }
 
   return data;
 };

--- a/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.ts
+++ b/src/utils/getResultsFromArrayBuffer/getResultsFromArrayBuffer.ts
@@ -77,6 +77,53 @@ const stringDecoderMap: Partial<Record<Datatype, string>> = {
 };
 
 /**
+ * Fast path for processing var-length string attributes.
+ * Decodes sub-buffers directly instead of decode→split→group→join.
+ * 
+ * @param arrayBuffer The main array buffer containing all data
+ * @param dataStart Starting byte offset of the string data
+ * @param dataLength Length of the string data in bytes
+ * @param byteOffsets Array of byte offsets for each string
+ * @param encoding Character encoding to use for decoding
+ * @param validityBuffer Optional buffer containing validity bytes for nullable strings
+ * @param ignoreNullables Whether to skip nullable processing
+ * @returns Array of strings (possibly with nulls if nullable)
+ */
+function processVarLengthStrings(
+  arrayBuffer: ArrayBuffer,
+  dataStart: number,
+  dataLength: number,
+  byteOffsets: bigint[],
+  encoding: string,
+  validityBuffer?: DataView,
+  ignoreNullables?: boolean
+): Result {
+  const decoder = new TextDecoder(encoding);
+  const numStrings = byteOffsets.length;
+  const strings: string[] = new Array(numStrings);
+
+  for (let i = 0; i < numStrings; i++) {
+    const start = Number(byteOffsets[i]);
+    const end = i + 1 < numStrings ? Number(byteOffsets[i + 1]) : dataLength;
+    strings[i] = decoder.decode(
+      new Uint8Array(arrayBuffer, dataStart + start, end - start)
+    );
+  }
+
+  // Apply nullability if needed
+  if (validityBuffer && !ignoreNullables) {
+    const nullablesTypedArray = bufferToInt8(validityBuffer);
+    const nullablesArray: number[] = new Array(nullablesTypedArray.length);
+    for (let i = 0; i < nullablesTypedArray.length; i++) {
+      nullablesArray[i] = nullablesTypedArray[i];
+    }
+    return setNullables(strings, nullablesArray);
+  }
+
+  return strings;
+}
+
+/**
  * Convert an ArrayBuffer to a map of attributes with their results
  * @param arrayBuffer The slice ArrayBuffer that contains the results
  * @param attributes
@@ -186,37 +233,23 @@ export const getResultsFromArrayBuffer = async (
     ) {
       const encoding =
         stringDecoderMap[selectedAttributeSchema.type] || 'utf-8';
-      const decoder = new TextDecoder(encoding);
-      const numStrings = byteOffsets.length;
-      const strings: string[] = new Array(numStrings);
-
-      for (let i = 0; i < numStrings; i++) {
-        const start = Number(byteOffsets[i]);
-        const end =
-          i + 1 < numStrings ? Number(byteOffsets[i + 1]) : dataLength;
-        strings[i] = decoder.decode(
-          new Uint8Array(arrayBuffer.buffer, dataStart + start, end - start)
-        );
-      }
-
-      let result: Result = strings;
-
-      if (isNullable && !options.ignoreNullables) {
-        const nullablesTypedArray = bufferToInt8(
-          new DataView(
+      const validityBuffer = isNullable
+        ? new DataView(
             arrayBuffer.buffer,
             arrayBuffer.byteOffset + byteOffset + validityOffset,
             totalNumberOfBytesOfAttribute - validityOffset
           )
-        );
-        const nullablesArray: number[] = new Array(nullablesTypedArray.length);
-        for (let i = 0; i < nullablesTypedArray.length; i++) {
-          nullablesArray[i] = nullablesTypedArray[i];
-        }
-        result = setNullables(strings, nullablesArray);
-      }
+        : undefined;
+      data[attribute.name] = processVarLengthStrings(
+        arrayBuffer.buffer,
+        dataStart,
+        dataLength,
+        byteOffsets,
+        encoding,
+        validityBuffer,
+        options.ignoreNullables
+      );
 
-      data[attribute.name] = result;
       byteOffset += totalNumberOfBytesOfAttribute;
       continue;
     }

--- a/src/utils/groupValuesByOffsetBytes/groupValuesByOffsetBytes.test.ts
+++ b/src/utils/groupValuesByOffsetBytes/groupValuesByOffsetBytes.test.ts
@@ -3,8 +3,8 @@ import convertToArray from '../convertToArray';
 import { describe, it, expect } from 'vitest';
 
 describe('groupValuesByOffsets()', () => {
-  it('Should group numbers by offsets', async () => {
-    const result = await groupValuesByOffsetBytes(
+  it('Should group numbers by offsets', () => {
+    const result = groupValuesByOffsetBytes(
       [33, 28, 35, 49, 122, 322, 199, 301, 234, 123, 99, 88],
       [0, 2, 3, 5, 9]
     );
@@ -17,14 +17,14 @@ describe('groupValuesByOffsets()', () => {
     ]);
   });
 
-  it('Should group values by offsets for strings', async () => {
+  it('Should group values by offsets for strings', () => {
     const offsets = [
       0, 11, 29, 39, 56, 66, 82, 92, 104, 112, 121, 135, 146, 160, 177, 196,
       208, 221, 230, 243, 251, 260, 268, 277, 287, 297, 308, 324, 337, 351, 364,
       371
     ];
     const str = `AMC JavelinCadillac FleetwoodCamaro Z28Chrysler ImperialDatsun 710Dodge ChallengerDuster 360Ferrari DinoFiat 128Fiat X1-9Ford Pantera LHonda CivicHornet 4 DriveHornet SportaboutLincoln ContinentalLotus EuropaMaserati BoraMazda RX4Mazda RX4 WagMerc 230Merc 240DMerc 280Merc 280CMerc 450SEMerc 450SLMerc 450SLCPontiac FirebirdPorsche 914-2Toyota CorollaToyota CoronaValiantVolvo 142E`;
-    const result = await groupValuesByOffsetBytes(convertToArray(str), offsets);
+    const result = groupValuesByOffsetBytes(convertToArray(str), offsets);
     expect(result.map(s => s.join(''))).toEqual([
       'AMC Javelin',
       'Cadillac Fleetwood',
@@ -63,7 +63,7 @@ describe('groupValuesByOffsets()', () => {
 
   it(
     'Should group values by offsets for strings',
-    async () => {
+    () => {
       const txt = 'TileDB';
       const limit = 100000;
       const strings = Array(limit).fill(txt);
@@ -72,7 +72,7 @@ describe('groupValuesByOffsets()', () => {
         .fill(0)
         .map((v, i) => i * txt.length);
 
-      const result = await groupValuesByOffsetBytes(
+      const result = groupValuesByOffsetBytes(
         convertToArray(str),
         offsets
       );

--- a/src/utils/groupValuesByOffsetBytes/groupValuesByOffsetBytes.ts
+++ b/src/utils/groupValuesByOffsetBytes/groupValuesByOffsetBytes.ts
@@ -1,46 +1,26 @@
-import range from '../range';
-import { Parallel, Serializable } from 'paralleljs';
-
 /**
  * Group values together according to offsets
  * @param vals [1, 2, 3, 4]
  * @param offsets e.g. [0, 3, 4]
- * @returns [[1,2,3], 4]
+ * @returns [[1,2,3], [4]]
  */
 const groupValuesByOffsetBytes = <T>(
   values: Array<T>,
   offsets: number[]
-): Promise<T[][]> => {
+): T[][] => {
   const offsetsLength = offsets.length;
   if (!offsetsLength) {
-    return Promise.resolve([values]);
+    return [values];
   }
-  const offsetIndex = range(0, offsetsLength - 1);
-  const offsetIndexTuple: [number, number][] = offsets.map((off, i) => [
-    off,
-    offsetIndex[i]
-  ]);
 
-  const offsetsP = new Parallel(
-    {
-      env: {
-        values,
-        offsets
-      }
-    },
-    offsetIndexTuple
-  );
+  const result: T[][] = new Array(offsetsLength);
+  for (let i = 0; i < offsetsLength; i++) {
+    const start = offsets[i];
+    const end = i + 1 < offsetsLength ? offsets[i + 1] : values.length;
+    result[i] = values.slice(start, end);
+  }
 
-  return offsetsP
-    .map<Array<T>>(([offset, i]) => {
-      const vals = global.env.values as Array<Serializable<T>>;
-      const globalOffsets = global.env.offsets;
-      const nextOffset = globalOffsets[i + 1];
-      // Note: Array.prototype.slice doesn't accept BigInt
-      const grpoupedValues = vals.slice(offset, nextOffset);
-      return grpoupedValues;
-    })
-    .finally(x => x);
+  return result;
 };
 
 export default groupValuesByOffsetBytes;

--- a/src/utils/setNullables/setNullables.ts
+++ b/src/utils/setNullables/setNullables.ts
@@ -1,16 +1,20 @@
 /**
- * Set nullables on an array
+ * Set nullables on an array (mutates in place)
  * @param vals [12, 15, 22, 34, 8]
  * @param nullables [0, 1, 1, 0, 1]
- * @param offsets []
  * @returns [NULL, 15, 22, NULL, 8]
  */
 const setNullables = <T>(
   values: Array<T>,
   nullables: number[]
 ): Array<T | null> => {
-  // We explicitly set as NULL index where nullable array is 0
-  return values.map((val, i) => (nullables[i] ? val : null));
+  const result = values as Array<T | null>;
+  for (let i = 0; i < result.length; i++) {
+    if (!nullables[i]) {
+      result[i] = null;
+    }
+  }
+  return result;
 };
 
 export default setNullables;


### PR DESCRIPTION
## Memory allocations
Use `TypedArray.prototype.subarray()` as much as possible which returns references from the same ArrayBuffer instead of copying buffers.
## Paralleljs
Removed `paralleljs` which was causing memory issues due to serializing (copying) data for every thread.
## Nullables
For every nullable attribute, `setNullables` was creating a brand-new array with `.map()`. Mutate in-place since the result array is already a fresh copy.
## Tests
Added performance tests to measure performance for `var-length` data and added tests for fast-path and non fast-path cases (UTF32).
## Performance measurements
*Before*
```
Big data var-length attributes performance (100K scale) > Should handle 100K var-length nullable strings efficiently
Big data var-length strings (100000 strings, ~34 avg bytes, 15% null): 3768.22ms
  Memory: Heap: +176.64MB

Big data var-length attributes performance (100K scale) > Should handle 100K var-length numeric arrays with variable sizes efficiently
Big data var-length Int32 arrays (100000 arrays, 1050000 total values, avg 10.5 per cell): 1426.83ms
  Memory: Heap: +299.26MB

Big data var-length attributes performance (100K scale) > Should handle 100K rows with multiple var-length attributes combined
Big data multi-attribute (100000 rows: fixed dim + var-len strings + var-len Int32[], 20%/25% null): 3367.25ms
  Memory: Heap: -306.48MB
```
*After*
```
Big data var-length attributes performance (100K scale) > Should handle 100K var-length nullable strings efficiently
Big data var-length strings (100000 strings, ~34 avg bytes, 15% null): 25.33ms
  Memory: Heap: +13.89MB

Big data var-length attributes performance (100K scale) > Should handle 100K var-length numeric arrays with variable sizes efficiently
Big data var-length Int32 arrays (100000 arrays, 1050000 total values, avg 10.5 per cell): 51.90ms
  Memory: Heap: -5.53MB

Big data var-length attributes performance (100K scale) > Should handle 100K rows with multiple var-length attributes combined
Big data multi-attribute (100000 rows: fixed dim + var-len strings + var-len Int32[], 20%/25% null): 47.96ms
  Memory: Heap: +27.72MB
```
In cases with 100.000 results we went from 306mb to 27.72mb.